### PR TITLE
Specify consensual history purge V1

### DIFF
--- a/.github/workflows/spec-validation.yml
+++ b/.github/workflows/spec-validation.yml
@@ -1,0 +1,28 @@
+name: Spec validation
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: spec-validation-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Deterministic spec validation
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check out exact revision
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Run fast and focused spec checks
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.repository.default_branch }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: python3 scripts/spec_validate.py --base "$BASE_SHA" --head "$HEAD_SHA" --mode all

--- a/app-components/README.md
+++ b/app-components/README.md
@@ -261,6 +261,9 @@ The following persistent GroupContext component is experimental and is not requi
 The frozen [marmot.group.encrypted-media.v1](./group-encrypted-media-v1.md) component remains documented for legacy
 bytes but is not part of the current profile.
 
+The adopted [marmot.group.history-purge.v1](./history-purge-v1.md) component is one-shot commit-scoped data in
+`AppEphemeral`; it never becomes a persistent GroupContext entry.
+
 Every Marmot leaf uses the adopted
 [marmot.member.account-identity-proof.v2](./account-identity-proof-v2.md) LeafNode component.
 

--- a/app-components/README.md
+++ b/app-components/README.md
@@ -261,8 +261,8 @@ The following persistent GroupContext component is experimental and is not requi
 The frozen [marmot.group.encrypted-media.v1](./group-encrypted-media-v1.md) component remains documented for legacy
 bytes but is not part of the current profile.
 
-The adopted [marmot.group.history-purge.v1](./history-purge-v1.md) component is one-shot commit-scoped data in
-`AppEphemeral`; it never becomes a persistent GroupContext entry.
+The adopted [marmot.group.history-purge.v1](./history-purge-v1.md) component uses temporary GroupContext state while
+one bounded request is open and one terminal `AppEphemeral` value in the Commit that removes that state.
 
 Every Marmot leaf uses the adopted
 [marmot.member.account-identity-proof.v2](./account-identity-proof-v2.md) LeafNode component.

--- a/app-components/README.md
+++ b/app-components/README.md
@@ -239,6 +239,12 @@ Group-level component proposals and commits are admin-gated by default.
 A component MAY define a looser rule, but it MUST do so explicitly. In v1, the admin set is defined by
 `marmot.group.admin-policy.v1`.
 
+A GroupContext component that temporarily requires its own component id MAY also define a narrower actor for the exact
+paired mutation of the GroupContext `app_components` required-component list. That exception MUST be stated in the
+owning component document, MUST add or remove only that component id, and MUST be atomic with the component transition
+that requires the list change. It does not authorize the actor to change any other required component or any unrelated
+GroupContext state.
+
 ## Current Marmot Components
 
 Assigned component ids are registered in [../foundation/registries.md](../foundation/registries.md).

--- a/app-components/history-purge-v1.md
+++ b/app-components/history-purge-v1.md
@@ -78,7 +78,14 @@ content    = "Approve deletion of pre-activation application plaintext"
 
 `group_id_hex` and `request_id_hex` are lowercase hexadecimal with no prefix. `parent_epoch_decimal` is canonical unsigned decimal ASCII with no leading zero except that zero itself is `"0"`. `decision` is exactly `"yes"` or `"no"`. The tags appear exactly once and in the order shown, and the event has no other tags. This signing event is not a transport event and MUST NOT be published to relays.
 
-The producer MUST set `proof.created_at` to its local current Unix time when requesting the signature. Receivers do not compare it with their local wall clock. The proof signer MUST be one of `request.members`. A conforming account MUST produce at most one decision for a `request_id`; a No therefore makes a unanimous authorization impossible. Silence, dismissal, timeout, and an invalid proof are not Yes.
+The producer MUST set `proof.created_at` to its local current Unix time when requesting the signature. Receivers do not compare it with their local wall clock. The proof signer MUST be one of `request.members`.
+
+A conforming account MUST produce at most one decision for a `request_id`. On accepting a member's first valid decision,
+a client records that decision durably for the request. An exact duplicate proof is idempotent. Every later distinct proof
+from that member for the same `request_id` is invalid, including a Yes proof after a No proof. A recorded No
+irrevocably rejects the request on that client: it MUST reject an authorizing Commit even if the Commit carries a
+different, correctly signed Yes proof from that member. Restart MUST preserve this terminal decision. A No therefore
+makes a unanimous authorization impossible. Silence, dismissal, timeout, and an invalid proof are not Yes.
 
 ## Purge control app events
 
@@ -120,7 +127,7 @@ struct {
 } MarmotHistoryPurgeAuthorizationV1;
 ```
 
-`approvals` contains exactly one 104-byte Yes proof for every identity in `request.members`, sorted by `proof.signer_pubkey` bytes. Missing, duplicate, extra, out-of-order, invalid, or No proofs invalidate the authorization.
+`approvals` contains exactly one 104-byte Yes proof for every identity in `request.members`, sorted by `proof.signer_pubkey` bytes. Missing, duplicate, extra, out-of-order, invalid, or No proofs invalidate the authorization. A Yes proof is invalid for this purpose when that client has already recorded a distinct decision from the signer for the request.
 
 ## Negotiation
 

--- a/app-components/history-purge-v1.md
+++ b/app-components/history-purge-v1.md
@@ -82,9 +82,10 @@ The producer MUST set `proof.created_at` to its local current Unix time when req
 
 A conforming account MUST produce at most one decision for a `request_id`. Before returning its first proof, the signer
 MUST record that decision durably. An exact retry returns the same proof; every request for a distinct proof for that
-`request_id` MUST be refused, including a request for Yes after No. Restart MUST preserve this signer state. A
-conforming signer that has produced No therefore cannot supply the Yes proof required for authorization. Silence,
-dismissal, timeout, and an invalid proof are not Yes.
+`request_id` MUST be refused, including a request for Yes after No. Restart and migration MUST preserve this local signer
+decision record until the implementation can prove that the request's bound parent can never again be a canonical
+candidate parent. A conforming signer that has produced No therefore cannot supply the Yes proof required for
+authorization. Silence, dismissal, timeout, and an invalid proof are not Yes.
 
 Receivers validate each proof only from the candidate parent, the request, and the proof bytes. Commit validation MUST
 NOT depend on whether a receiver previously observed or stored a response application message. Consequently, every
@@ -175,4 +176,10 @@ recovery material.
 
 ## Removal and migration
 
-This component has no persistent state to remove or replace. V1 defines one-shot pre-activation application-plaintext deletion only. It does not authorize sender retraction, administrator moderation, local delete-for-me, custom prompts, arbitrary ranges, or secure erasure. An incompatible request, proof, carrier, or target rule requires a new component id and proof event kind.
+This component creates no persistent group state to remove or replace. The local signer decision records required above
+are persistent local state, not component state. Migration or cleanup MUST retain each record unless it can prove that
+the request's bound parent can never again be a canonical candidate parent; removing a record earlier MUST NOT enable a
+second or changed proof for its `request_id`. V1 defines one-shot pre-activation application-plaintext deletion only. It
+does not authorize sender retraction, administrator moderation, local delete-for-me, custom prompts, arbitrary ranges,
+or secure erasure. An incompatible request, proof, carrier, or target rule requires a new component id and proof event
+kind.

--- a/app-components/history-purge-v1.md
+++ b/app-components/history-purge-v1.md
@@ -2,22 +2,30 @@
 
 Status: adopted.
 
-`marmot.group.history-purge.v1` carries one unanimous, commit-scoped authorization to remove application plaintext from before a new retention policy takes effect. It does not create persistent group state.
+`marmot.group.history-purge.v1` carries one bounded consensual request from an application event into temporary canonical
+GroupContext state, records each member's single decision, and carries the terminal authorization in `AppEphemeral`. The
+accepted terminal transition may authorize removal of application plaintext from before a new retention policy takes
+effect. It does not authorize deleting protocol recovery material or copies outside a conforming member's controlled
+stores.
 
-## Registry
+## Registry and locations
 
 - Component id: `0x800d`
 - Name: `marmot.group.history-purge.v1`
 - Purge control app-event kind: `453`
 - Member decision proof kind: `454`
-- Valid carrier: one inline MLS `AppEphemeral` proposal in the authorizing Commit
+- Request proof kind: `455`
+- Cancellation proof kind: `456`
+- Terminal proof kind: `457`
+- Valid locations: a temporary GroupContext entry while one request is open, and one terminal `AppEphemeral` value in
+  the Commit that removes that entry
 - Default requirement: optional
 
-The component is invalid as component data in a GroupContext, LeafNode, KeyPackage, or GroupInfo and is invalid as a SafeAAD item.
+A group supports this feature only when every nonblank leaf advertises `app_ephemeral`, `app_data_update`, and component
+`0x800d`. An open request requires `0x800d` in the GroupContext required-component list. A terminal Commit atomically
+removes both the entry and that temporary requirement.
 
 ## Request bytes
-
-The request binds the complete candidate parent state, the replacement retention duration, and the active account identities that must decide:
 
 ```text
 struct {
@@ -25,23 +33,62 @@ struct {
 } MarmotHistoryPurgeMemberV1;
 
 struct {
+  uint32 leaf_index;
+  opaque account_pubkey[32];
+  uint8 app_ephemeral_supported;
+  uint8 history_purge_supported;
+} MarmotHistoryPurgeCapabilityLeafV1;
+
+struct {
+  MarmotHistoryPurgeCapabilityLeafV1 leaves<38..38912>;
+} MarmotHistoryPurgeCapabilityStateV1;
+
+struct {
   opaque group_id<1..255>;
   uint64 parent_epoch;
   opaque parent_group_context_hash[32];
+  opaque proposer_pubkey[32];
+  uint64 created_at;
+  uint64 expires_at;
+  uint8 prior_retention_present;
+  uint64 prior_retention_secs;
   uint64 target_retention_secs;
   MarmotHistoryPurgeMemberV1 members<32..32768>;
+  opaque capability_state_hash[32];
+} MarmotHistoryPurgeRequestCoreV1;
+
+struct {
+  MarmotHistoryPurgeRequestCoreV1 core;
+  MarmotAuthorizationProof proposer_proof;
 } MarmotHistoryPurgeRequestV1;
 ```
 
-These structures use the Marmot binary profile in [../foundation/canonical-encoding.md](../foundation/canonical-encoding.md). `members` contains between one and 1024 entries, sorted by `account_pubkey` bytes with no duplicate. It MUST equal the sorted unique set of 32-byte Marmot account identities in all nonblank leaves of the candidate parent state.
+These structures use the Marmot binary profile in
+[../foundation/canonical-encoding.md](../foundation/canonical-encoding.md). `members` contains between one and 1024
+entries, sorted by `account_pubkey` bytes without duplicates. It MUST equal the sorted unique set of Marmot account
+identities in all nonblank leaves of the candidate parent state. `proposer_pubkey` MUST be in that set.
 
-`group_id`, `parent_epoch`, and `parent_group_context_hash` MUST equal the candidate parent's MLS GroupContext, where:
+`prior_retention_present` is `0` or `1`. When it is `0`, `prior_retention_secs` MUST be zero and the bound parent has no
+`marmot.group.message-retention.v1` entry. When it is `1`, `prior_retention_secs` MUST equal the exact effective value in
+that parent. `target_retention_secs` follows the value bounds in
+[message-retention-v1.md](./message-retention-v1.md).
+
+For every nonblank parent leaf, up to 1024 leaves, a validator constructs one
+`MarmotHistoryPurgeCapabilityLeafV1` in increasing `leaf_index` order. Both support bytes are `0` or `1` and are derived
+from that leaf's authenticated MLS capabilities and Marmot component support. The request is eligible only when both
+bytes are `1` for every entry. The bound digest is:
 
 ```text
-parent_group_context_hash = SHA-256(TLS-serialize(candidate_parent_group_context))
+capability_state_hash = SHA-256(
+  "marmot-history-purge-capabilities-v1" ||
+  0x00 ||
+  encode(MarmotHistoryPurgeCapabilityStateV1)
+)
 ```
 
-The TLS serialization is owned by MLS and is not re-encoded with the Marmot binary profile. Its tree hash and confirmed transcript hash bind the request to the exact parent state, including the active leaves and prior commits. `target_retention_secs` MUST differ from the retention value in that parent. An absent `marmot.group.message-retention.v1` component is read as zero for this comparison.
+The request interval is absolute Unix time in whole seconds. `created_at` MUST equal
+`proposer_proof.created_at`; `expires_at` MUST be greater than `created_at` and no more than `604800` seconds later.
+V1 has no caller-selected prompt text and permits at most one open request per group.
 
 The request identity is:
 
@@ -49,15 +96,67 @@ The request identity is:
 request_id = SHA-256(
   "marmot-history-purge-request-v1" ||
   0x00 ||
-  encode(MarmotHistoryPurgeRequestV1)
+  encode(MarmotHistoryPurgeRequestCoreV1)
 )
 ```
 
-The domain string is 31 ASCII bytes. The encoded request supplies an unambiguous boundary for every variable field.
+## Request proof and non-admin route
 
-## Member decision proof
+The proposer proof uses the common envelope in
+[../foundation/authorization-proofs.md](../foundation/authorization-proofs.md). A verifier reconstructs this local-only
+Nostr event:
 
-Each account in `request.members` makes exactly one explicit Yes or No decision by producing a `MarmotAuthorizationProof` from [../foundation/authorization-proofs.md](../foundation/authorization-proofs.md). Construct this exact local-only Nostr event:
+```text
+pubkey     = lowercase-hex(proposer_proof.signer_pubkey)
+created_at = proposer_proof.created_at
+kind       = 455
+tags       = [
+  ["d", "marmot-history-purge-request-v1"],
+  ["component", "0x800d"],
+  ["group_id", group_id_hex],
+  ["parent_epoch", parent_epoch_decimal],
+  ["request", request_id_hex]
+]
+content    = lowercase-hex(SHA-256(encode(MarmotHistoryPurgeRequestCoreV1)))
+```
+
+The proof signer MUST equal `proposer_pubkey` and be an active member in the bound parent. Kind `455` is a signing
+template and MUST NOT be published to relays.
+
+Any active member, including a non-admin, MAY create and send the request app event below. Any active member MAY relay a
+valid request into an `AppDataUpdate` that adds the temporary GroupContext entry; the proposer proof, not relay identity,
+authenticates creation. This explicit feature-owned app route does not loosen the active-admin requirement for the
+retention update or accepted finalization.
+
+## Open state and decision updates
+
+```text
+uint8 MarmotHistoryPurgeDecisionV1; // 1 = yes, 2 = no
+
+struct {
+  MarmotHistoryPurgeDecisionV1 decision;
+  MarmotAuthorizationProof proof;
+} MarmotHistoryPurgeDecisionRecordV1;
+
+struct {
+  MarmotHistoryPurgeRequestV1 request;
+  MarmotHistoryPurgeDecisionRecordV1 yes_decisions<0..107520>;
+} MarmotHistoryPurgeOpenStateV1;
+```
+
+The GroupContext component data is exactly one encoded `MarmotHistoryPurgeOpenStateV1`. `yes_decisions` contains at
+most one record per account, sorted by `proof.signer_pubkey`, and every record MUST have decision `1`. A state update is
+a full replacement. From an existing state it may add exactly one previously absent Yes record and may change no other
+byte. The proposal sender MUST equal that record's signer, and both sender and committer MUST be active members in the
+bound cohort. A member's own Yes is the only decision that may remain in open state.
+
+A No is not an advisory app event and is never stored as an open-state value. It is a terminal response carried in the
+rejected finalization Commit below. The No signer MAY commit that response directly. Consequently, after a valid No is
+on the selected canonical branch, the component entry is gone and no later Yes can replace it. Competing same-parent
+terminal Commits remain ordinary candidate branches; canonical convergence chooses one transition, and off-branch
+proof delivery cannot mutate the selected state.
+
+A decision proof reconstructs the kind `454` event:
 
 ```text
 pubkey     = lowercase-hex(proof.signer_pubkey)
@@ -71,31 +170,119 @@ tags       = [
   ["request", request_id_hex],
   ["decision", decision]
 ]
-content    = "Approve deletion of pre-activation application plaintext"
-             when decision is "yes", otherwise
-             "Reject deletion of pre-activation application plaintext"
+content    = ""
 ```
 
-`group_id_hex` and `request_id_hex` are lowercase hexadecimal with no prefix. `parent_epoch_decimal` is canonical unsigned decimal ASCII with no leading zero except that zero itself is `"0"`. `decision` is exactly `"yes"` or `"no"`. The tags appear exactly once and in the order shown, and the event has no other tags. This signing event is not a transport event and MUST NOT be published to relays.
+`decision` in the event is exactly `yes` or `no`. The signer MUST occur in `members`. The proof timestamp MUST be from
+`created_at` through `expires_at`, inclusive. These byte comparisons, rather than a verifier's wall clock, determine
+Commit validity. A conforming signer MUST durably remember the first decision it signed for a request through expiry
+and MUST refuse a second or conflicting decision. The response identity is:
 
-The producer MUST set `proof.created_at` to its local current Unix time when requesting the signature. Receivers do not compare it with their local wall clock. The proof signer MUST be one of `request.members`.
+```text
+response_id = SHA-256(
+  "marmot-history-purge-response-v1" ||
+  0x00 || request_id || decision || encode(proof)
+)
+```
 
-A conforming account MUST produce at most one decision for a `request_id`. Before returning its first proof, the signer
-MUST record that decision durably. An exact retry returns the same proof; every request for a distinct proof for that
-`request_id` MUST be refused, including a request for Yes after No. Restart and migration MUST preserve this local signer
-decision record until the implementation can prove that the request's bound parent can never again be a canonical
-candidate parent. A conforming signer that has produced No therefore cannot supply the Yes proof required for
-authorization. Silence, dismissal, timeout, and an invalid proof are not Yes.
+## Cancellation
 
-Receivers validate each proof only from the candidate parent, the request, and the proof bytes. Commit validation MUST
-NOT depend on whether a receiver previously observed or stored a response application message. Consequently, every
-conforming validator reaches the same result for the same candidate parent and authorizing Commit bytes.
+The proposer may cancel only while the request is open. The cancellation proof uses kind `456` with the exact tags
+below and empty content:
 
-## Purge control app events
+```text
+[
+  ["d", "marmot-history-purge-cancellation-v1"],
+  ["component", "0x800d"],
+  ["group_id", group_id_hex],
+  ["parent_epoch", parent_epoch_decimal],
+  ["request", request_id_hex]
+]
+```
 
-Requests and responses use kind `453` Marmot app events carried as ordinary MLS application messages. Their shared envelope follows [../foundation/application-messages.md](../foundation/application-messages.md).
+Its signer MUST equal `proposer_pubkey`, and its timestamp MUST be from `created_at` through `expires_at`, inclusive.
+The cancellation identity is:
 
-A request event has exactly these tags:
+```text
+cancellation_id = SHA-256(
+  "marmot-history-purge-cancellation-v1" ||
+  0x00 || request_id || encode(cancellation_proof)
+)
+```
+
+A cancellation app event may distribute this proof, but cancellation becomes authoritative only in the selected
+terminal Commit. A cancelled, rejected, expired, or superseded request cannot reopen and requires a new request id.
+
+## Terminal finalization bytes
+
+```text
+uint8 MarmotHistoryPurgeTerminalV1;
+// 1 = accepted, 2 = rejected, 3 = cancelled, 4 = expired, 5 = superseded
+
+struct {
+  opaque request_id[32];
+  MarmotHistoryPurgeTerminalV1 terminal;
+} MarmotHistoryPurgeFinalizationCoreV1;
+
+struct {
+  MarmotHistoryPurgeFinalizationCoreV1 core;
+  MarmotAuthorizationProof authorization;
+} MarmotHistoryPurgeFinalizationV1;
+```
+
+The finalization is the only component `0x800d` value in one inline `AppEphemeral` proposal in the terminal Commit. Its
+identity is:
+
+```text
+finalization_id = SHA-256(
+  "marmot-history-purge-finalization-v1" ||
+  0x00 || encode(MarmotHistoryPurgeFinalizationV1)
+)
+```
+
+The authorization envelope is interpreted by terminal value:
+
+- `accepted`: kind `457`, signed by the active-admin committer, with a timestamp no later than `expires_at`; the parent
+  open state contains exactly one valid Yes for every `members` account;
+- `rejected`: the kind `454` No decision proof; its signer is an active cohort member and MUST equal the Commit sender;
+- `cancelled`: the kind `456` cancellation proof; its signer is the proposer and MUST equal the Commit sender;
+- `expired`: kind `457`, signed by the active-admin committer, with a timestamp greater than `expires_at`;
+- `superseded`: kind `457`, signed by the committer of the canonical membership, identity, capability, admin-policy, or
+  retention change that invalidates a request binding.
+
+For kind `457`, the local signing event has exact tags:
+
+```text
+[
+  ["d", "marmot-history-purge-terminal-v1"],
+  ["component", "0x800d"],
+  ["group_id", group_id_hex],
+  ["parent_epoch", parent_epoch_decimal],
+  ["request", request_id_hex],
+  ["terminal", terminal]
+]
+```
+
+Its content is lowercase hex of `SHA-256(encode(MarmotHistoryPurgeFinalizationCoreV1))`. The `terminal` tag value is
+exactly `accepted`, `rejected`, `cancelled`, `expired`, or `superseded`, corresponding to terminal values 1 through 5.
+Kind `457` is local-only and MUST NOT be relayed.
+
+Every terminal Commit removes the GroupContext `0x800d` entry and its temporary required-component listing. An accepted
+Commit additionally contains exactly one full-replacement update for `marmot.group.message-retention.v1` with
+`target_retention_secs`. Other terminal Commits contain no retention update. Except for the exact canonical-state change
+that causes `superseded`, a terminal Commit contains no proposal beyond the history-purge removal, required-component
+removal, the terminal `AppEphemeral`, and the accepted retention update when applicable. Any missing, duplicate, or
+extra proposal makes the terminal transition invalid.
+
+The accepted Commit is the sole purge linearization point. Neither a request, a Yes, a No proof that has not reached a
+selected Commit, nor local expiry starts suppression or deletion. The first terminal transition on the selected
+canonical branch wins; later replayed finalizations are inert because no matching open component remains.
+
+## Request, cancellation, and receipt app events
+
+All control messages are MLS-protected Marmot app payloads of kind `453`; they are not relay-level Nostr events.
+
+A request event has exact tags:
 
 ```text
 [
@@ -105,81 +292,89 @@ A request event has exactly these tags:
 ]
 ```
 
-Its `content` is standard padded base64 of the exact `MarmotHistoryPurgeRequestV1` bytes. The MLS-authenticated sender MUST be an active administrator in the bound parent state. A recipient ignores the request unless the bytes decode exactly, reproduce the tagged `request_id`, match its current canonical state, and pass the negotiation rules below.
+Its content is standard padded base64 of the exact `MarmotHistoryPurgeRequestV1` bytes. The MLS-authenticated sender MUST
+equal `proposer_pubkey`.
 
-A response event has exactly these tags:
+A cancellation event has the same `v` and `request` tags, `type` equal to `cancellation`, and content equal to padded
+base64 of the exact cancellation proof. The authenticated sender MUST be the proposer.
+
+A receipt event has exact tags:
 
 ```text
 [
   ["v", "marmot-history-purge-v1"],
-  ["type", "response"],
-  ["request", request_id_hex],
-  ["decision", decision]
+  ["type", "receipt"],
+  ["finalization", finalization_id_hex],
+  ["outcome", outcome]
 ]
 ```
 
-Its `content` is standard padded base64 of exactly one 104-byte `MarmotAuthorizationProof`. The MLS-authenticated sender account MUST equal `proof.signer_pubkey`, the proof MUST reconstruct the tagged decision for the exact request, and the signer MUST occur in `request.members`. Invalid control events are ignored as feature data; they do not invalidate the carrying MLS application message or alter group state.
-
-## AppEphemeral authorization bytes
-
-The inline `AppEphemeral` proposal uses component id `0x800d` and this data:
+Its content is empty. `outcome` is exactly `applied` or `failed`. The authenticated sender MUST be one member account in
+the accepted request cohort. A sender emits at most one receipt for a finalization. `applied` may be emitted only after
+all of that account's controlled conforming stores complete the required idempotent cleanup; `failed` is a terminal
+coarse result when they cannot. The receipt identity is:
 
 ```text
-struct {
-  MarmotHistoryPurgeRequestV1 request;
-  MarmotAuthorizationProof approvals<104..106496>;
-} MarmotHistoryPurgeAuthorizationV1;
+receipt_id = SHA-256(
+  "marmot-history-purge-receipt-v1" ||
+  0x00 || finalization_id || sender_account_pubkey || outcome
+)
 ```
 
-`approvals` contains exactly one 104-byte Yes proof for every identity in `request.members`, sorted by `proof.signer_pubkey` bytes. Missing, duplicate, extra, out-of-order, invalid, or No proofs invalidate the authorization. Validation uses only the candidate parent, request, and authorization bytes; a receiver's locally observed response history cannot change the result.
+Receipts expose no message id, content hash, filename, per-message count, device inventory, failure reason, or cleanup
+timestamp. Although MLS authenticates each sender, the user-visible group projection MUST expose only the aggregate
+outcome, not a member-by-member or device-by-device table.
 
-## Negotiation
+## Expiry and restart
 
-Before emitting a request, every nonblank leaf in the bound parent state MUST advertise proposal type `app_ephemeral` (`0x0009`) and component id `0x800d`. The GroupContext MUST permit `app_ephemeral` under MLS RequiredCapabilities. A leaf that does not advertise both values blocks the feature; it is never treated as consenting.
+A client uses `expires_at` for its local open-request UI and MUST retain or reconstruct the request id, deadline, first
+signed decision, canonical open state, accepted suppression boundary, cleanup progress, and emitted receipt across
+restart. At or after its local `expires_at`, it stops offering Yes/No and treats timeout only as a provisional local
+`expired` projection. Expiry is never consent. Canonical expiry requires the terminal Commit above, so Commit validation
+never depends on receiver clock skew. A valid accepted finalization signed inside the response interval remains valid
+when delivered late unless another terminal transition already won canonically.
 
-The component id need not be in the GroupContext required-component list because the authorization is one-shot and commit-scoped. A client MUST NOT add a persistent `0x800d` dictionary entry.
+## Application and completion projections
 
-## Commit authorization and validation
+An accepted finalization produces these stable projections:
 
-Only an active administrator in the candidate parent state MAY commit the purge authorization. The authorizing Commit MUST:
+- `accepted`: the accepted finalization is canonical; cleanup has not yet finished locally;
+- `applying`: the target range is hidden locally and idempotent cleanup is in progress;
+- `local_applied`: local cleanup is durable and the account's `applied` receipt has been emitted;
+- `group_complete`: one valid `applied` receipt has been observed for every account in the request cohort;
+- `partially_completed`: at least one valid receipt has been observed, but the set is not all-`applied`, or any valid
+  `failed` receipt has been observed.
 
-- apply directly to the request's exact candidate parent;
-- have a complete proposal set consisting of exactly one inline `0x800d` `AppEphemeral` proposal carrying this
-  authorization and exactly one `marmot.group.message-retention.v1` full-replacement `AppDataUpdate` whose value equals
-  `request.target_retention_secs`;
-- reject every other proposal or component mutation, including a standalone or second `0x800d` proposal, an
-  `AppEphemeral` proposal for any other component id, any other `AppDataUpdate`, and any MLS proposal type other than
-  the two allowed proposals, whether inline or referenced; and
-- satisfy every request, negotiation, approval, ordinary MLS, and candidate-parent authorization rule above.
+`accepted` is wire-authoritative. The other four are local projections from durable cleanup state and the valid receipt
+set; different clients may learn receipts at different times. Missing, offline, unsupported, or failed application MUST
+NOT be presented as `group_complete`.
 
-The retention `AppDataUpdate` MAY be inline or a valid referenced proposal. Resolving that reference does not widen the
-allowed set. The Commit's required UpdatePath, confirmation tag, and other mandatory MLS framing are not proposals and
-remain governed by the ordinary MLS validation rule; they do not permit another proposal or app-component mutation.
+## Target boundary and deletion gate
 
-The Commit that satisfies these rules is the request's only valid finalization. Its resulting epoch is the activation epoch. Any other canonical child of the bound parent expires the request without purge, including a membership, capability, admin-policy, or retention change. Local wall clocks and transport arrival order do not decide validity.
+The target is application plaintext whose MLS source epoch is less than the accepted Commit's resulting epoch. It
+excludes MLS Commits and proposals, retained recovery anchors, candidate state, pending publication obligations,
+audit/security material required for protocol correctness, and messages already governed by another independent delete
+action.
 
-The authorization is invalid for any other group, parent state, epoch, member set, target retention value, or Commit shape. Replay of the same Commit follows ordinary Marmot duplicate handling and MUST NOT create a second deletion effect.
+A client MUST durably install one reversible suppression boundary before exposing the accepted effect. Target payloads,
+including late or replayed arrivals, are suppressed before timeline, search, notification, export, reply-preview, TTS,
+or media-cache presentation. Suppression follows the selected branch and is withdrawn if convergence supersedes the
+authorizing Commit while its parent remains inside the rollback horizon.
 
-## Effect boundary
+Best-effort destructive cleanup begins only after the authorization remains selected and its parent is outside the
+rollback horizon. Cleanup is idempotent by `(request_id, activation_epoch)`, checkpoints before exposing
+`local_applied`, resumes after restart, and never deletes required protocol recovery material. Logical removal is not a
+physical-overwrite guarantee. Former members, hostile or non-conforming clients, relays, exports, screenshots, backups,
+and external copies are outside enforceable scope.
 
-While the authorizing Commit is selected, each conforming client applies the reversible suppression effect defined by
-[../features/consensual-history-purge.md](../features/consensual-history-purge.md) and
-[../protocol-core/retained-history.md](../protocol-core/retained-history.md). The target is delivered application
-plaintext whose MLS source epoch is less than the activation epoch. If convergence supersedes the authorizing Commit
-while its parent remains inside the rollback horizon, the client withdraws that suppression with the Commit's other
-application effects and MUST NOT have destructively deleted the target.
+## Validation, removal, and migration
 
-Local best-effort deletion becomes eligible only after convergence is settled, the selected branch still contains the
-authorizing Commit, and the request's parent epoch is outside the current tip's rollback horizon. At that point no
-eligible branch can supersede the authorization. The authorization never deletes or shortens retention for protocol
-recovery material.
+A decoder rejects noncanonical bytes, unknown enum values, invalid keys or proofs, malformed bounds, duplicate members
+or decisions, a mismatched parent/request/capability/retention binding, and any update that is not one permitted
+transition above. A membership, identity, capability, admin-policy, or retention change while open MUST atomically
+supersede and remove the request; it cannot silently drop a voter or bind a newcomer.
 
-## Removal and migration
-
-This component creates no persistent group state to remove or replace. The local signer decision records required above
-are persistent local state, not component state. Migration or cleanup MUST retain each record unless it can prove that
-the request's bound parent can never again be a canonical candidate parent; removing a record earlier MUST NOT enable a
-second or changed proof for its `request_id`. V1 defines one-shot pre-activation application-plaintext deletion only. It
-does not authorize sender retraction, administrator moderation, local delete-for-me, custom prompts, arbitrary ranges,
-or secure erasure. An incompatible request, proof, carrier, or target rule requires a new component id and proof event
-kind.
+No valid persistent state may be removed without the matching terminal `AppEphemeral`. The component cannot be enabled
+for a group containing an unsupported leaf. Legacy groups continue without it. A future incompatible request, state,
+proof, finalization, receipt, or authorization rule requires a new component id and new proof kinds; V1 bytes MUST NOT
+be reinterpreted.

--- a/app-components/history-purge-v1.md
+++ b/app-components/history-purge-v1.md
@@ -1,0 +1,161 @@
+# marmot.group.history-purge.v1
+
+Status: adopted.
+
+`marmot.group.history-purge.v1` carries one unanimous, commit-scoped authorization to remove application plaintext from before a new retention policy takes effect. It does not create persistent group state.
+
+## Registry
+
+- Component id: `0x800d`
+- Name: `marmot.group.history-purge.v1`
+- Purge control app-event kind: `453`
+- Member decision proof kind: `454`
+- Valid carrier: one inline MLS `AppEphemeral` proposal in the authorizing Commit
+- Default requirement: optional
+
+The component is invalid as component data in a GroupContext, LeafNode, KeyPackage, or GroupInfo and is invalid as a SafeAAD item.
+
+## Request bytes
+
+The request binds the complete candidate parent state, the replacement retention duration, and the active account identities that must decide:
+
+```text
+struct {
+  opaque account_pubkey[32];
+} MarmotHistoryPurgeMemberV1;
+
+struct {
+  opaque group_id<1..255>;
+  uint64 parent_epoch;
+  opaque parent_group_context_hash[32];
+  uint64 target_retention_secs;
+  MarmotHistoryPurgeMemberV1 members<32..32768>;
+} MarmotHistoryPurgeRequestV1;
+```
+
+These structures use the Marmot binary profile in [../foundation/canonical-encoding.md](../foundation/canonical-encoding.md). `members` contains between one and 1024 entries, sorted by `account_pubkey` bytes with no duplicate. It MUST equal the sorted unique set of 32-byte Marmot account identities in all nonblank leaves of the candidate parent state.
+
+`group_id`, `parent_epoch`, and `parent_group_context_hash` MUST equal the candidate parent's MLS GroupContext, where:
+
+```text
+parent_group_context_hash = SHA-256(TLS-serialize(candidate_parent_group_context))
+```
+
+The TLS serialization is owned by MLS and is not re-encoded with the Marmot binary profile. Its tree hash and confirmed transcript hash bind the request to the exact parent state, including the active leaves and prior commits. `target_retention_secs` MUST differ from the retention value in that parent. An absent `marmot.group.message-retention.v1` component is read as zero for this comparison.
+
+The request identity is:
+
+```text
+request_id = SHA-256(
+  "marmot-history-purge-request-v1" ||
+  0x00 ||
+  encode(MarmotHistoryPurgeRequestV1)
+)
+```
+
+The domain string is 31 ASCII bytes. The encoded request supplies an unambiguous boundary for every variable field.
+
+## Member decision proof
+
+Each account in `request.members` makes exactly one explicit Yes or No decision by producing a `MarmotAuthorizationProof` from [../foundation/authorization-proofs.md](../foundation/authorization-proofs.md). Construct this exact local-only Nostr event:
+
+```text
+pubkey     = lowercase-hex(proof.signer_pubkey)
+created_at = proof.created_at
+kind       = 454
+tags       = [
+  ["d", "marmot-history-purge-decision-v1"],
+  ["component", "0x800d"],
+  ["group_id", group_id_hex],
+  ["parent_epoch", parent_epoch_decimal],
+  ["request", request_id_hex],
+  ["decision", decision]
+]
+content    = "Approve deletion of pre-activation application plaintext"
+             when decision is "yes", otherwise
+             "Reject deletion of pre-activation application plaintext"
+```
+
+`group_id_hex` and `request_id_hex` are lowercase hexadecimal with no prefix. `parent_epoch_decimal` is canonical unsigned decimal ASCII with no leading zero except that zero itself is `"0"`. `decision` is exactly `"yes"` or `"no"`. The tags appear exactly once and in the order shown, and the event has no other tags. This signing event is not a transport event and MUST NOT be published to relays.
+
+The producer MUST set `proof.created_at` to its local current Unix time when requesting the signature. Receivers do not compare it with their local wall clock. The proof signer MUST be one of `request.members`. A conforming account MUST produce at most one decision for a `request_id`; a No therefore makes a unanimous authorization impossible. Silence, dismissal, timeout, and an invalid proof are not Yes.
+
+## Purge control app events
+
+Requests and responses use kind `453` Marmot app events carried as ordinary MLS application messages. Their shared envelope follows [../foundation/application-messages.md](../foundation/application-messages.md).
+
+A request event has exactly these tags:
+
+```text
+[
+  ["v", "marmot-history-purge-v1"],
+  ["type", "request"],
+  ["request", request_id_hex]
+]
+```
+
+Its `content` is standard padded base64 of the exact `MarmotHistoryPurgeRequestV1` bytes. The MLS-authenticated sender MUST be an active administrator in the bound parent state. A recipient ignores the request unless the bytes decode exactly, reproduce the tagged `request_id`, match its current canonical state, and pass the negotiation rules below.
+
+A response event has exactly these tags:
+
+```text
+[
+  ["v", "marmot-history-purge-v1"],
+  ["type", "response"],
+  ["request", request_id_hex],
+  ["decision", decision]
+]
+```
+
+Its `content` is standard padded base64 of exactly one 104-byte `MarmotAuthorizationProof`. The MLS-authenticated sender account MUST equal `proof.signer_pubkey`, the proof MUST reconstruct the tagged decision for the exact request, and the signer MUST occur in `request.members`. Invalid control events are ignored as feature data; they do not invalidate the carrying MLS application message or alter group state.
+
+## AppEphemeral authorization bytes
+
+The inline `AppEphemeral` proposal uses component id `0x800d` and this data:
+
+```text
+struct {
+  MarmotHistoryPurgeRequestV1 request;
+  MarmotAuthorizationProof approvals<104..106496>;
+} MarmotHistoryPurgeAuthorizationV1;
+```
+
+`approvals` contains exactly one 104-byte Yes proof for every identity in `request.members`, sorted by `proof.signer_pubkey` bytes. Missing, duplicate, extra, out-of-order, invalid, or No proofs invalidate the authorization.
+
+## Negotiation
+
+Before emitting a request, every nonblank leaf in the bound parent state MUST advertise proposal type `app_ephemeral` (`0x0009`) and component id `0x800d`. The GroupContext MUST permit `app_ephemeral` under MLS RequiredCapabilities. A leaf that does not advertise both values blocks the feature; it is never treated as consenting.
+
+The component id need not be in the GroupContext required-component list because the authorization is one-shot and commit-scoped. A client MUST NOT add a persistent `0x800d` dictionary entry.
+
+## Commit authorization and validation
+
+Only an active administrator in the candidate parent state MAY commit the purge authorization. The authorizing Commit MUST:
+
+- apply directly to the request's exact candidate parent;
+- contain exactly one inline `0x800d` `AppEphemeral` proposal and no standalone or second `0x800d` proposal;
+- contain exactly one `marmot.group.message-retention.v1` full-replacement update whose value equals `request.target_retention_secs`;
+- contain no membership proposal, admin-policy change, required-capability change, other app-component update, or app-component removal; and
+- satisfy every request, negotiation, approval, ordinary MLS, and candidate-parent authorization rule above.
+
+The Commit that satisfies these rules is the request's only valid finalization. Its resulting epoch is the activation epoch. Any other canonical child of the bound parent expires the request without purge, including a membership, capability, admin-policy, or retention change. Local wall clocks and transport arrival order do not decide validity.
+
+The authorization is invalid for any other group, parent state, epoch, member set, target retention value, or Commit shape. Replay of the same Commit follows ordinary Marmot duplicate handling and MUST NOT create a second deletion effect.
+
+## Effect boundary
+
+While the authorizing Commit is selected, each conforming client applies the reversible suppression effect defined by
+[../features/consensual-history-purge.md](../features/consensual-history-purge.md) and
+[../protocol-core/retained-history.md](../protocol-core/retained-history.md). The target is delivered application
+plaintext whose MLS source epoch is less than the activation epoch. If convergence supersedes the authorizing Commit
+while its parent remains inside the rollback horizon, the client withdraws that suppression with the Commit's other
+application effects and MUST NOT have destructively deleted the target.
+
+Local best-effort deletion becomes eligible only after convergence is settled, the selected branch still contains the
+authorizing Commit, and the request's parent epoch is outside the current tip's rollback horizon. At that point no
+eligible branch can supersede the authorization. The authorization never deletes or shortens retention for protocol
+recovery material.
+
+## Removal and migration
+
+This component has no persistent state to remove or replace. V1 defines one-shot pre-activation application-plaintext deletion only. It does not authorize sender retraction, administrator moderation, local delete-for-me, custom prompts, arbitrary ranges, or secure erasure. An incompatible request, proof, carrier, or target rule requires a new component id and proof event kind.

--- a/app-components/history-purge-v1.md
+++ b/app-components/history-purge-v1.md
@@ -80,12 +80,15 @@ content    = "Approve deletion of pre-activation application plaintext"
 
 The producer MUST set `proof.created_at` to its local current Unix time when requesting the signature. Receivers do not compare it with their local wall clock. The proof signer MUST be one of `request.members`.
 
-A conforming account MUST produce at most one decision for a `request_id`. On accepting a member's first valid decision,
-a client records that decision durably for the request. An exact duplicate proof is idempotent. Every later distinct proof
-from that member for the same `request_id` is invalid, including a Yes proof after a No proof. A recorded No
-irrevocably rejects the request on that client: it MUST reject an authorizing Commit even if the Commit carries a
-different, correctly signed Yes proof from that member. Restart MUST preserve this terminal decision. A No therefore
-makes a unanimous authorization impossible. Silence, dismissal, timeout, and an invalid proof are not Yes.
+A conforming account MUST produce at most one decision for a `request_id`. Before returning its first proof, the signer
+MUST record that decision durably. An exact retry returns the same proof; every request for a distinct proof for that
+`request_id` MUST be refused, including a request for Yes after No. Restart MUST preserve this signer state. A
+conforming signer that has produced No therefore cannot supply the Yes proof required for authorization. Silence,
+dismissal, timeout, and an invalid proof are not Yes.
+
+Receivers validate each proof only from the candidate parent, the request, and the proof bytes. Commit validation MUST
+NOT depend on whether a receiver previously observed or stored a response application message. Consequently, every
+conforming validator reaches the same result for the same candidate parent and authorizing Commit bytes.
 
 ## Purge control app events
 
@@ -127,7 +130,7 @@ struct {
 } MarmotHistoryPurgeAuthorizationV1;
 ```
 
-`approvals` contains exactly one 104-byte Yes proof for every identity in `request.members`, sorted by `proof.signer_pubkey` bytes. Missing, duplicate, extra, out-of-order, invalid, or No proofs invalidate the authorization. A Yes proof is invalid for this purpose when that client has already recorded a distinct decision from the signer for the request.
+`approvals` contains exactly one 104-byte Yes proof for every identity in `request.members`, sorted by `proof.signer_pubkey` bytes. Missing, duplicate, extra, out-of-order, invalid, or No proofs invalidate the authorization. Validation uses only the candidate parent, request, and authorization bytes; a receiver's locally observed response history cannot change the result.
 
 ## Negotiation
 

--- a/app-components/history-purge-v1.md
+++ b/app-components/history-purge-v1.md
@@ -248,7 +248,7 @@ The authorization envelope is interpreted by terminal value:
 - `cancelled`: the kind `456` cancellation proof; its signer is the proposer and MUST equal the Commit sender;
 - `expired`: kind `457`, signed by the active-admin committer, with a timestamp greater than `expires_at`;
 - `superseded`: kind `457`, signed by the committer of the canonical membership, identity, capability, admin-policy, or
-  retention change that invalidates a request binding.
+  retention change that invalidates a request binding; the signer MUST equal the terminal Commit sender.
 
 For kind `457`, the local signing event has exact tags:
 
@@ -263,9 +263,10 @@ For kind `457`, the local signing event has exact tags:
 ]
 ```
 
-Its content is lowercase hex of `SHA-256(encode(MarmotHistoryPurgeFinalizationCoreV1))`. The `terminal` tag value is
-exactly `accepted`, `rejected`, `cancelled`, `expired`, or `superseded`, corresponding to terminal values 1 through 5.
-Kind `457` is local-only and MUST NOT be relayed.
+Its content is lowercase hex of `SHA-256(encode(MarmotHistoryPurgeFinalizationCoreV1))`. For kind `457`, `terminal` is
+exactly `accepted`, `expired`, or `superseded`, corresponding to terminal values 1, 4, and 5. Rejected and cancelled
+finalizations use kinds `454` and `456`, respectively; they do not use kind `457`. Kind `457` is local-only and MUST
+NOT be relayed.
 
 Every terminal Commit removes the GroupContext `0x800d` entry and its temporary required-component listing. An accepted
 Commit additionally contains exactly one full-replacement update for `marmot.group.message-retention.v1` with

--- a/app-components/history-purge-v1.md
+++ b/app-components/history-purge-v1.md
@@ -133,10 +133,17 @@ The component id need not be in the GroupContext required-component list because
 Only an active administrator in the candidate parent state MAY commit the purge authorization. The authorizing Commit MUST:
 
 - apply directly to the request's exact candidate parent;
-- contain exactly one inline `0x800d` `AppEphemeral` proposal and no standalone or second `0x800d` proposal;
-- contain exactly one `marmot.group.message-retention.v1` full-replacement update whose value equals `request.target_retention_secs`;
-- contain no membership proposal, admin-policy change, required-capability change, other app-component update, or app-component removal; and
+- have a complete proposal set consisting of exactly one inline `0x800d` `AppEphemeral` proposal carrying this
+  authorization and exactly one `marmot.group.message-retention.v1` full-replacement `AppDataUpdate` whose value equals
+  `request.target_retention_secs`;
+- reject every other proposal or component mutation, including a standalone or second `0x800d` proposal, an
+  `AppEphemeral` proposal for any other component id, any other `AppDataUpdate`, and any MLS proposal type other than
+  the two allowed proposals, whether inline or referenced; and
 - satisfy every request, negotiation, approval, ordinary MLS, and candidate-parent authorization rule above.
+
+The retention `AppDataUpdate` MAY be inline or a valid referenced proposal. Resolving that reference does not widen the
+allowed set. The Commit's required UpdatePath, confirmation tag, and other mandatory MLS framing are not proposals and
+remain governed by the ordinary MLS validation rule; they do not permit another proposal or app-component mutation.
 
 The Commit that satisfies these rules is the request's only valid finalization. Its resulting epoch is the activation epoch. Any other canonical child of the bound parent expires the request without purge, including a membership, capability, admin-policy, or retention change. Local wall clocks and transport arrival order do not decide validity.
 

--- a/app-components/history-purge-v1.md
+++ b/app-components/history-purge-v1.md
@@ -36,11 +36,12 @@ struct {
   uint32 leaf_index;
   opaque account_pubkey[32];
   uint8 app_ephemeral_supported;
+  uint8 app_data_update_supported;
   uint8 history_purge_supported;
 } MarmotHistoryPurgeCapabilityLeafV1;
 
 struct {
-  MarmotHistoryPurgeCapabilityLeafV1 leaves<38..38912>;
+  MarmotHistoryPurgeCapabilityLeafV1 leaves<39..39936>;
 } MarmotHistoryPurgeCapabilityStateV1;
 
 struct {
@@ -74,9 +75,9 @@ that parent. `target_retention_secs` follows the value bounds in
 [message-retention-v1.md](./message-retention-v1.md).
 
 For every nonblank parent leaf, up to 1024 leaves, a validator constructs one
-`MarmotHistoryPurgeCapabilityLeafV1` in increasing `leaf_index` order. Both support bytes are `0` or `1` and are derived
-from that leaf's authenticated MLS capabilities and Marmot component support. The request is eligible only when both
-bytes are `1` for every entry. The bound digest is:
+`MarmotHistoryPurgeCapabilityLeafV1` in increasing `leaf_index` order. All three support bytes are `0` or `1` and are
+derived from that leaf's authenticated MLS capabilities and Marmot component support. The request is eligible only when
+all three bytes are `1` for every entry. The bound digest is:
 
 ```text
 capability_state_hash = SHA-256(
@@ -127,6 +128,12 @@ Any active member, including a non-admin, MAY create and send the request app ev
 valid request into an `AppDataUpdate` that adds the temporary GroupContext entry; the proposer proof, not relay identity,
 authenticates creation. This explicit feature-owned app route does not loosen the active-admin requirement for the
 retention update or accepted finalization.
+
+The member that relays a valid request is authorized to commit only the exact paired addition of the `0x800d`
+GroupContext entry and `0x800d` required-component listing. For every terminal transition, the actor authorized below is
+also authorized to commit only the exact paired removal of that entry and listing. These feature-owned exceptions to
+the default GroupContext authorization do not permit changing any other required component or unrelated GroupContext
+state.
 
 ## Open state and decision updates
 
@@ -242,9 +249,10 @@ finalization_id = SHA-256(
 
 The authorization envelope is interpreted by terminal value:
 
-- `accepted`: kind `457`, signed by the active-admin committer, with a timestamp no later than `expires_at`; the parent
-  open state contains exactly one valid Yes for every `members` account;
-- `rejected`: the kind `454` No decision proof; its signer is an active cohort member and MUST equal the Commit sender;
+- `accepted`: kind `457`, signed by the active-admin committer, with a timestamp from `created_at` through `expires_at`,
+  inclusive; the parent open state contains exactly one valid Yes for every `members` account;
+- `rejected`: the kind `454` No decision proof; its signer is an active cohort member, MUST equal the Commit sender, and
+  MUST NOT already occur in the parent open state's `yes_decisions`;
 - `cancelled`: the kind `456` cancellation proof; its signer is the proposer and MUST equal the Commit sender;
 - `expired`: kind `457`, signed by the active-admin committer, with a timestamp greater than `expires_at`;
 - `superseded`: kind `457`, signed by the committer of the canonical membership, identity, capability, admin-policy, or

--- a/app-components/history-purge-v1.md
+++ b/app-components/history-purge-v1.md
@@ -69,6 +69,9 @@ These structures use the Marmot binary profile in
 entries, sorted by `account_pubkey` bytes without duplicates. It MUST equal the sorted unique set of Marmot account
 identities in all nonblank leaves of the candidate parent state. `proposer_pubkey` MUST be in that set.
 
+`parent_group_context_hash` MUST equal `SHA-256(TLS-serialize(candidate_parent_group_context))`. The input is the MLS
+TLS serialization of the complete candidate parent GroupContext used directly, without Marmot-specific re-encoding.
+
 `prior_retention_present` is `0` or `1`. When it is `0`, `prior_retention_secs` MUST be zero and the bound parent has no
 `marmot.group.message-retention.v1` entry. When it is `1`, `prior_retention_secs` MUST equal the exact effective value in
 that parent. `target_retention_secs` follows the value bounds in
@@ -318,10 +321,12 @@ A receipt event has exact tags:
 ]
 ```
 
-Its content is empty. `outcome` is exactly `applied` or `failed`. The authenticated sender MUST be one member account in
-the accepted request cohort. A sender emits at most one receipt for a finalization. `applied` may be emitted only after
-all of that account's controlled conforming stores complete the required idempotent cleanup; `failed` is a terminal
-coarse result when they cannot. The receipt identity is:
+Its content is empty. `outcome` is exactly `applied` or `failed`. A receipt is valid only when `finalization_id` identifies
+the accepted finalization on the selected canonical branch. A receipt that identifies a rejected, cancelled, expired,
+superseded, or non-canonical finalization is invalid and MUST NOT contribute to a completion projection. The
+authenticated sender MUST be one member account in the accepted request cohort. A sender emits at most one receipt for
+a finalization. `applied` may be emitted only after all of that account's controlled conforming stores complete the
+required idempotent cleanup; `failed` is a terminal coarse result when they cannot. The receipt identity is:
 
 ```text
 receipt_id = SHA-256(

--- a/app-components/message-retention-v1.md
+++ b/app-components/message-retention-v1.md
@@ -23,7 +23,9 @@ Any nonzero value is a requested application retention duration in seconds.
 
 Each application message pins the retention state from its own MLS source epoch. Later component updates or removal do
 not shorten, extend, or restore that message's expiry. A retry or transport republication of the same MLS message uses
-the same pinned duration and expiry value.
+the same pinned duration and expiry value. The only adopted exception is the separately negotiated, unanimous local
+plaintext effect in [marmot.group.history-purge.v1](./history-purge-v1.md); that one-shot authorization does not change
+the pinned expiry value or the prospective default.
 
 The retention duration is signed group state, and the transport-level expiry timestamp uses the exact calculation
 defined below. Transport expiry applies to application messages only: group-state history — commits and proposals —
@@ -61,7 +63,7 @@ group state and MUST NOT invalidate otherwise-valid retention state received fro
 
 This component governs application plaintext retention. It MUST NOT force deletion of MLS state, retained anchors,
 pending message records, publish obligations, or other protocol data before the protocol retention rules allow that data
-to be discarded.
+to be discarded. A consensual history purge remains subject to the same protocol-data exclusion.
 
 ## Authorization
 

--- a/features/README.md
+++ b/features/README.md
@@ -20,6 +20,8 @@ they used to be described in a MIP. The old-to-new MIP map lives in [../mip-cove
   streams, anchored by normal durable final messages.
 - [push-notifications.md](./push-notifications.md) - optional native push notification flow.
 - [multi-device.md](./multi-device.md) - branch-draft multi-device support.
+- [consensual-history-purge.md](./consensual-history-purge.md) - unanimous one-shot deletion of pre-activation
+  application plaintext alongside a prospective retention change.
 
 ## Relationship to app components
 

--- a/features/consensual-history-purge.md
+++ b/features/consensual-history-purge.md
@@ -2,51 +2,118 @@
 
 Status: adopted.
 
-Consensual history purge is a narrow, one-shot flow for changing a group's prospective disappearing-message duration while asking every active member to remove application plaintext from before the change. It is not remote wipe, moderation, sender retraction, or an arbitrary-range deletion protocol.
+This feature is a separate, high-consequence group action for changing prospective message retention and, only after
+unanimous consent, hiding and best-effort deleting pre-activation application plaintext. It is not implied by enabling
+or changing disappearing messages.
 
-## Surfaces
+The exact request, proof, temporary state, terminal finalization, receipt, TTL, and identity bytes are owned by
+[`marmot.group.history-purge.v1`](../app-components/history-purge-v1.md). Prospective retention state remains owned by
+[`marmot.group.message-retention.v1`](../app-components/message-retention-v1.md). Canonical branch selection and the
+rollback horizon remain owned by [convergence](../protocol-core/convergence.md) and
+[durability](../protocol-core/durability.md).
 
-- [`marmot.group.history-purge.v1`](../app-components/history-purge-v1.md) owns the request bytes, member decision proof, control app event, committed authorization, negotiation, and validation.
-- [`marmot.group.message-retention.v1`](../app-components/message-retention-v1.md) owns the replacement prospective retention state.
-- [Retained history](../protocol-core/retained-history.md) owns the boundary between application plaintext and protocol recovery material.
-- [Durability](../protocol-core/durability.md) owns restart-safe application effects.
+## Eligibility and capability gate
 
-## Starting one request
+The rich action is available only when every nonblank active leaf advertises the required MLS proposal support,
+`AppEphemeral`, and component `0x800d`. A client MUST NOT emit a request when any active leaf is unsupported or when a
+request is already open. An old or unsupported client is never counted as consenting.
 
-An active administrator MAY start one request for the group's current canonical parent state. The request fixes the proposed retention duration and the complete sorted set of active member account identities. It is valid only while that exact parent remains canonical, so V1 has no independent distributed request state and no custom expiry clock.
+Any active member may create a request, including a non-admin. The member signs the versioned request proof and sends
+the feature-owned kind `453` app event. The request may then be relayed into the temporary GroupContext component by an
+active member. This route exists specifically so non-admin request creation does not weaken authorization: only an
+active admin may commit the accepted finalization and the retention update.
 
-The administrator MUST NOT emit the request unless every active leaf advertises V1 support. The UI MUST show the proposed duration, that all pre-activation application plaintext is in scope, the active account identities that must decide, that any No or the next unrelated Commit ends the request without deletion, and the external-copy limits below. V1 has no custom prompt text.
+The request binds the group and parent state, proposer, prior and target retention values, exact active-account cohort,
+capability-state digest, creation time, and deadline. Membership, account identity, capability, admin policy, or
+retention changes while it is open supersede it; the client requires a new request id rather than silently removing a
+voter or binding a newcomer.
 
-A client presents exactly two explicit, accessible actions: Yes and No. Dismissal, timeout, silence, leaving the screen, and a preselected control are not consent. Each account produces at most one signed answer for the exact request. A No ends the request for conforming participants because that account cannot also provide the Yes proof required by finalization.
+## Consent flow
 
-Only one request per group SHOULD be presented at a time. A second request does not cancel or supersede the first; each remains independently bound to its parent, and at most one can be finalized because ordinary convergence selects only one canonical child.
+The request UI MUST show:
 
-## Unanimous finalization
+- the proposed retention duration;
+- the complete active-member cohort;
+- that the target is application plaintext from before the accepted activation epoch, not protocol recovery state;
+- the absolute expiry and the consequences of Yes and No;
+- that cleanup is cooperative and cannot guarantee removal from former, hostile, unsupported, or offline
+  non-conforming clients, relays, exports, screenshots, backups, or other external copies.
 
-No deletion occurs when the request or an individual response is received. An active administrator may construct the authorizing Commit only after collecting one valid Yes proof from every account in the fixed snapshot.
+Yes and No are explicit accessible actions. Dismissal, Back, process death, silence, and timeout are not decisions and
+never imply consent. No control is preselected, and V1 carries no custom prompt text.
 
-The Commit atomically carries the canonical unanimous authorization and activates the exact requested retention value. It must be the direct child of the request's parent and may not mix membership, admin, capability, or unrelated component changes. The resulting epoch is the activation epoch.
+A member's Yes becomes canonical through the component's one-record state update. A No is submitted as the rejected
+terminal Commit rather than as an advisory event. The selected No transition removes the open component, so later Yes
+material cannot replace it. A conforming signer durably refuses to sign two decisions for one request. Competing
+same-parent terminal Commits are resolved only by canonical convergence; relay arrival order and locally observed proof
+order never choose group state.
 
-Any No prevents a conforming unanimous authorization. Any other canonical child Commit expires the request without deletion. A join, removal, leave, member-identity replacement, capability change, admin-policy change, or different retention change necessarily changes the bound parent or violates the allowed Commit shape, so a fresh request is required. Transport order, receipt order, and local clocks are not authority.
+The proposer may cancel only while open, using the versioned cancellation proof and terminal Commit. Expiry is bounded
+to at most seven days by request bytes. At the local deadline a client stops offering responses and persists a
+provisional expired projection across restart, but expiry never means consent. Canonical accepted, rejected, cancelled,
+expired, and superseded outcomes are the versioned terminal finalizations defined by the component owner. Rejected,
+cancelled, expired, and superseded requests require a new request id.
 
-## Local application
+## Atomic finalization
 
-While the authorizing Commit is on the selected branch, a client MUST suppress from application surfaces every delivered Marmot app payload whose MLS source epoch is less than the activation epoch. Suppression covers conversation history, search, notifications, exports created by the application, reply previews, text-to-speech, thumbnails, and application-controlled plaintext media caches. If convergence supersedes that Commit while its parent is still inside the rollback horizon, the client withdraws the suppression with the Commit's other application effects; it cannot already have destroyed the plaintext.
+Acceptance requires one canonical Yes from every account in the bound cohort. The active-admin Commit atomically:
 
-The client begins idempotent local best-effort deletion only after convergence is settled, the selected branch still contains the authorizing Commit, and the request's parent epoch is outside the current tip's rollback horizon. This irreversible-effect gate is part of the purge contract, not an implementation delay: no still-eligible branch can then supersede the authorization. The client keys deletion by `request_id` and activation epoch, durably records or reconstructs the suppression boundary before exposing the post-activation view, and resumes unfinished cleanup after restart. Reprocessing the same Commit cannot duplicate the effect. A late or replayed target payload is suppressed before any application surface can render or emit it.
+1. sets the exact requested retention value;
+2. removes the temporary request state and requirement;
+3. carries the accepted finalization bytes; and
+4. installs the logical pre-activation suppression effect.
 
-An offline conforming client validates and applies the canonical authorization before rendering newly recovered target history. A member that was offline while votes were collected is never assumed to agree; without its Yes proof the authorizing Commit is invalid.
+The component owner's exact proposal-set rule rejects missing, duplicate, or unrelated proposals. No client starts
+suppression or deletion from a request, an individual Yes, an uncommitted No proof, local expiry, or receipt. The
+accepted Commit is the linearization point.
 
-Clients MAY report only local states such as "approved" and "removed on this device". V1 defines no cleanup receipt, group-wide completion claim, per-member application tracking, partial-completion state, message count, deleted-content hash, filename list, device inventory, or precise cleanup timestamp.
+The target is application plaintext whose MLS source epoch precedes the accepted Commit's resulting epoch. It excludes
+MLS Commits and proposals, retained recovery anchors, candidate state, pending publication obligations, required audit
+or security material, and content already governed by an independent delete action. This one-shot flow does not change
+the prospective retention invariant for ordinary timer changes.
 
-## Preserved data and limits
+## Crash-safe application and late arrivals
 
-The purge does not change the prospective invariant in [`marmot.group.message-retention.v1`](../app-components/message-retention-v1.md): without a valid unanimous authorization, a later retention update never shortens, extends, or restores an earlier message's expiry.
+After accepted finalization, each conforming member installs a reversible suppression boundary before rendering the
+target again. The boundary covers timeline, search, notifications, exports, reply previews, TTS, and media caches.
+Late, replayed, or newly recovered pre-boundary app payloads are suppressed before presentation.
 
-The local effect removes application plaintext only. It MUST NOT remove MLS group state, commits, proposals, retained anchors, candidate-parent material, pending publication obligations, replay markers, encrypted transport objects needed for protocol operation, or audit/security records required for correctness before their owning protocol release rules permit it.
+A client checkpoints the effect before exposing progress, applies cleanup idempotently by request id and activation
+epoch, resumes at every restart boundary, and emits no applied receipt before all stores it controls have finished.
+Suppression follows canonical branch selection. If convergence supersedes the authorization while its parent is still
+inside the rollback horizon, suppression is withdrawn and destructive cleanup has not begun. Best-effort deletion starts
+only after the selected authorization is outside that horizon.
 
-The effect is best effort, not secure erasure. Marmot cannot force deletion from former members, hostile or non-conforming clients, relays, recipients outside the fixed cohort, screenshots, independent exports, device or cloud backups, filesystem snapshots, or copies held by another application. Storage encryption and physical overwrite are platform concerns. A client MUST NOT describe the action as removing every copy or as group-wide completion.
+Logical removal is not a physical-overwrite claim. Storage encryption, filesystem behavior, platform backups, exports,
+and non-conforming copies limit secure-erasure guarantees.
 
-## Scope exclusions
+## Results and privacy
 
-V1 authorizes exactly the pre-activation application-plaintext range for one retention activation. It does not authorize a custom range, selected messages, sender retraction, admin moderation, delete-for-me, group disbanding, cleanup receipts, or a continuing retention policy. Those require separate designs and cannot reinterpret this component.
+The versioned finalization and receipt identities are defined by the component owner. User-visible status separates:
+
+- `accepted`: canonical consent and authorization exist;
+- `applying`: this account is suppressing and cleaning its controlled stores;
+- `local_applied`: this account completed durable cleanup and emitted its applied receipt;
+- `group_complete`: one applied receipt is known for every account in the bound cohort;
+- `partially_completed`: receipt evidence exists but is not all-applied, or a member emitted a coarse failed receipt.
+
+Only `accepted` is a canonical wire outcome. Application and completion values are local projections over durable local
+state and authenticated receipts; clients may learn them at different times. Missing, offline, unsupported, or failed
+members MUST NOT be shown as complete.
+
+The UI MUST expose only the privacy-minimizing aggregate result. It MUST NOT show a member/device cleanup table, message
+ids, deleted-content hashes, filenames, per-message counts, device inventory, precise cleanup timing, or detailed
+failure reasons. The protocol still authenticates each receipt sender so duplicate and forged receipts can be rejected.
+
+## Boundaries
+
+This feature does not grant or modify authority for sender retraction, admin moderation, delete-for-me, general group
+disbanding, arbitrary historical ranges, or physical remote wipe. Those actions require their own scopes and identities.
+Normal prospective retention remains the default when no accepted purge finalization exists.
+
+## Conformance
+
+The normative matrix is in [foundation conformance](../foundation/conformance.md). It covers non-admin request creation,
+unanimous acceptance, explicit No, cancellation, expiry and restart, duplicate/conflicting decisions, terminal races,
+request replay, membership/admin/capability changes, unsupported clients, rollback-horizon behavior, crash recovery,
+late target messages, privacy-minimizing receipts, and complete versus partial result projection.

--- a/features/consensual-history-purge.md
+++ b/features/consensual-history-purge.md
@@ -1,0 +1,52 @@
+# Consensual history purge
+
+Status: adopted.
+
+Consensual history purge is a narrow, one-shot flow for changing a group's prospective disappearing-message duration while asking every active member to remove application plaintext from before the change. It is not remote wipe, moderation, sender retraction, or an arbitrary-range deletion protocol.
+
+## Surfaces
+
+- [`marmot.group.history-purge.v1`](../app-components/history-purge-v1.md) owns the request bytes, member decision proof, control app event, committed authorization, negotiation, and validation.
+- [`marmot.group.message-retention.v1`](../app-components/message-retention-v1.md) owns the replacement prospective retention state.
+- [Retained history](../protocol-core/retained-history.md) owns the boundary between application plaintext and protocol recovery material.
+- [Durability](../protocol-core/durability.md) owns restart-safe application effects.
+
+## Starting one request
+
+An active administrator MAY start one request for the group's current canonical parent state. The request fixes the proposed retention duration and the complete sorted set of active member account identities. It is valid only while that exact parent remains canonical, so V1 has no independent distributed request state and no custom expiry clock.
+
+The administrator MUST NOT emit the request unless every active leaf advertises V1 support. The UI MUST show the proposed duration, that all pre-activation application plaintext is in scope, the active account identities that must decide, that any No or the next unrelated Commit ends the request without deletion, and the external-copy limits below. V1 has no custom prompt text.
+
+A client presents exactly two explicit, accessible actions: Yes and No. Dismissal, timeout, silence, leaving the screen, and a preselected control are not consent. Each account produces at most one signed answer for the exact request. A No ends the request for conforming participants because that account cannot also provide the Yes proof required by finalization.
+
+Only one request per group SHOULD be presented at a time. A second request does not cancel or supersede the first; each remains independently bound to its parent, and at most one can be finalized because ordinary convergence selects only one canonical child.
+
+## Unanimous finalization
+
+No deletion occurs when the request or an individual response is received. An active administrator may construct the authorizing Commit only after collecting one valid Yes proof from every account in the fixed snapshot.
+
+The Commit atomically carries the canonical unanimous authorization and activates the exact requested retention value. It must be the direct child of the request's parent and may not mix membership, admin, capability, or unrelated component changes. The resulting epoch is the activation epoch.
+
+Any No prevents a conforming unanimous authorization. Any other canonical child Commit expires the request without deletion. A join, removal, leave, member-identity replacement, capability change, admin-policy change, or different retention change necessarily changes the bound parent or violates the allowed Commit shape, so a fresh request is required. Transport order, receipt order, and local clocks are not authority.
+
+## Local application
+
+While the authorizing Commit is on the selected branch, a client MUST suppress from application surfaces every delivered Marmot app payload whose MLS source epoch is less than the activation epoch. Suppression covers conversation history, search, notifications, exports created by the application, reply previews, text-to-speech, thumbnails, and application-controlled plaintext media caches. If convergence supersedes that Commit while its parent is still inside the rollback horizon, the client withdraws the suppression with the Commit's other application effects; it cannot already have destroyed the plaintext.
+
+The client begins idempotent local best-effort deletion only after convergence is settled, the selected branch still contains the authorizing Commit, and the request's parent epoch is outside the current tip's rollback horizon. This irreversible-effect gate is part of the purge contract, not an implementation delay: no still-eligible branch can then supersede the authorization. The client keys deletion by `request_id` and activation epoch, durably records or reconstructs the suppression boundary before exposing the post-activation view, and resumes unfinished cleanup after restart. Reprocessing the same Commit cannot duplicate the effect. A late or replayed target payload is suppressed before any application surface can render or emit it.
+
+An offline conforming client validates and applies the canonical authorization before rendering newly recovered target history. A member that was offline while votes were collected is never assumed to agree; without its Yes proof the authorizing Commit is invalid.
+
+Clients MAY report only local states such as "approved" and "removed on this device". V1 defines no cleanup receipt, group-wide completion claim, per-member application tracking, partial-completion state, message count, deleted-content hash, filename list, device inventory, or precise cleanup timestamp.
+
+## Preserved data and limits
+
+The purge does not change the prospective invariant in [`marmot.group.message-retention.v1`](../app-components/message-retention-v1.md): without a valid unanimous authorization, a later retention update never shortens, extends, or restores an earlier message's expiry.
+
+The local effect removes application plaintext only. It MUST NOT remove MLS group state, commits, proposals, retained anchors, candidate-parent material, pending publication obligations, replay markers, encrypted transport objects needed for protocol operation, or audit/security records required for correctness before their owning protocol release rules permit it.
+
+The effect is best effort, not secure erasure. Marmot cannot force deletion from former members, hostile or non-conforming clients, relays, recipients outside the fixed cohort, screenshots, independent exports, device or cloud backups, filesystem snapshots, or copies held by another application. Storage encryption and physical overwrite are platform concerns. A client MUST NOT describe the action as removing every copy or as group-wide completion.
+
+## Scope exclusions
+
+V1 authorizes exactly the pre-activation application-plaintext range for one retention activation. It does not authorize a custom range, selected messages, sender retraction, admin moderation, delete-for-me, group disbanding, cleanup receipts, or a continuing retention policy. Those require separate designs and cannot reinterpret this component.

--- a/foundation/conformance.md
+++ b/foundation/conformance.md
@@ -87,34 +87,49 @@ snapshot encoding, process scheduler, or one snapshot per epoch. The owning norm
 
 Conformance suites for [`marmot.group.history-purge.v1`](../app-components/history-purge-v1.md) MUST cover:
 
-1. a supported fixed member snapshot in which every account answers Yes and the direct child Commit atomically applies
-   the requested retention value and one reversible pre-activation plaintext suppression boundary;
-2. each missing, duplicate, extra, out-of-order, malformed, wrong-request, wrong-group, wrong-parent, and No approval,
-   verifying that no retention update or deletion effect is accepted;
-3. one explicit No and one silent member, verifying that neither produces a partial or group-wide completion state;
-   then deliver one member's valid No response to client A but not client B, restart that member's signer, and request a
-   distinct Yes proof for the same request. The conforming signer MUST refuse to produce the Yes proof. For each of two
-   same-parent candidate Commits, one with that member's approval missing and one carrying that member's No proof,
-   deliver the exact same Commit bytes to clients A and B. Both clients MUST reject the Commit with identical effect
-   projections despite their asymmetric response delivery: no retention, suppression, or deletion effect starts;
-4. a membership, identity, capability, admin-policy, retention, or unrelated canonical child Commit before
-   finalization, verifying that the old request expires and cannot authorize a later Commit;
-5. a leaf without `app_ephemeral` or component `0x800d` support, verifying that request creation and finalization are
-   blocked rather than treating the leaf as consenting;
-6. an otherwise-valid authorization Commit carrying an unrelated `AppEphemeral` component id or any other extra
-   proposal, verifying rejection with no retention, suppression, or deletion effect;
-7. a branch that supersedes the authorizing Commit while its parent remains inside the rollback horizon, verifying that
-   suppression is withdrawn and destructive deletion has not begun;
-8. advancement until the request parent is outside the rollback horizon, verifying that best-effort deletion begins
-   only while the authorization remains on the settled selected branch;
-9. duplicate delivery and restart at the prepared, confirmed-not-applied, suppression-observed, deletion-eligible,
-   partially cleaned, and effect-observed boundaries, verifying one suppression boundary, completion of all remaining
-   eligible deletion work after restart, and one effective output per stable effect identity; and
-10. late or replayed pre-activation app payloads after activation, verifying suppression before delivery while retained
-   anchors, candidate state, pending publication, and other protocol recovery material remain available.
+1. an active non-admin creates the feature-owned request, another active member relays it into temporary GroupContext
+   state, and no actor thereby gains authority to commit the retention update or accepted finalization;
+2. a supported fixed member snapshot in which every account adds one canonical Yes and the active-admin terminal Commit
+   atomically applies the requested retention value, removes the temporary state, and installs one reversible
+   pre-activation plaintext suppression boundary;
+3. each missing, duplicate, extra, out-of-order, malformed, wrong-request, wrong-group, wrong-parent, late, and
+   wrong-signer decision, verifying that no accepted retention, suppression, or deletion effect begins;
+4. one member produces and canonically commits No, client A observes the No material before the Commit while client B
+   does not, and both then receive the exact rejected Commit bytes. Both clients MUST select the same rejected terminal
+   identity. After restart, a later Yes state update or accepted finalization for that request MUST be invalid and no
+   suppression or deletion begins. A signer asked for No then Yes before terminal selection MUST durably refuse the
+   second proof; a validator presented conflicting proofs MUST reject them;
+5. proposer cancellation while open, cancellation by any other member, cancellation after a terminal transition, and
+   replay of a valid cancellation, verifying that only the first case can become the canonical cancelled identity;
+6. request intervals at one second and exactly `604800` seconds, an interval of `604801`, Yes and accepted-proof
+   timestamps immediately before, at, and after the deadline, local expiry across restart, and canonical expiry. The
+   suite MUST verify that timeout, silence, restart, and expiry never produce consent;
+7. a membership, identity, capability, admin-policy, or retention change while open, verifying atomic supersession,
+   removal of the old state, and rejection of later material for its request id;
+8. a leaf without `app_ephemeral`, `app_data_update`, or component `0x800d` support, verifying that request creation and
+   finalization are blocked rather than treating the leaf as consenting;
+9. every terminal proposal set with each required proposal missing or duplicated and with one unrelated proposal added,
+   verifying rejection with no retention, suppression, or deletion effect;
+10. competing same-parent accepted, rejected, cancelled, expired, and superseded terminal Commits delivered in
+    different orders, verifying that canonical convergence alone selects one stable terminal identity and replays of
+    losing transitions are inert;
+11. a branch that supersedes the authorizing Commit while its parent remains inside the rollback horizon, verifying that
+    suppression is withdrawn and destructive deletion has not begun;
+12. advancement until the request parent is outside the rollback horizon, verifying that best-effort deletion begins
+    only while the authorization remains on the settled selected branch;
+13. duplicate delivery and restart at the prepared, confirmed-not-applied, suppression-observed, deletion-eligible,
+    partially cleaned, and effect-observed boundaries, verifying one suppression boundary, completion of remaining
+    eligible cleanup after restart, and one effective output per stable effect identity;
+14. late or replayed pre-activation app payloads after activation, verifying suppression before delivery while retained
+    anchors, candidate state, pending publication, and other protocol recovery material remain available; and
+15. duplicate, forged, wrong-finalization, applied, failed, and missing receipts. The suite MUST verify one receipt per
+    account, no receipt before durable local cleanup, aggregate-only presentation, `group_complete` only with all-applied
+    cohort receipts, and `partially_completed` without message, file, count, device, precise-time, or failure-detail
+    leakage.
 
-The suite MUST compare canonical state and stable effect identities. It MUST NOT claim physical overwrite, deletion of
-external copies, or completion on another member's device.
+The suite MUST compare canonical state and the versioned request, response, cancellation, finalization, receipt, and
+stable effect identities. It MUST NOT claim physical overwrite, deletion of external copies, or completion on another
+member's device.
 
 ## Exporter commitment
 

--- a/foundation/conformance.md
+++ b/foundation/conformance.md
@@ -96,14 +96,16 @@ Conformance suites for [`marmot.group.history-purge.v1`](../app-components/histo
    finalization, verifying that the old request expires and cannot authorize a later Commit;
 5. a leaf without `app_ephemeral` or component `0x800d` support, verifying that request creation and finalization are
    blocked rather than treating the leaf as consenting;
-6. a branch that supersedes the authorizing Commit while its parent remains inside the rollback horizon, verifying that
+6. an otherwise-valid authorization Commit carrying an unrelated `AppEphemeral` component id or any other extra
+   proposal, verifying rejection with no retention, suppression, or deletion effect;
+7. a branch that supersedes the authorizing Commit while its parent remains inside the rollback horizon, verifying that
    suppression is withdrawn and destructive deletion has not begun;
-7. advancement until the request parent is outside the rollback horizon, verifying that best-effort deletion begins
+8. advancement until the request parent is outside the rollback horizon, verifying that best-effort deletion begins
    only while the authorization remains on the settled selected branch;
-8. duplicate delivery and restart at the prepared, confirmed-not-applied, suppression-observed, deletion-eligible,
+9. duplicate delivery and restart at the prepared, confirmed-not-applied, suppression-observed, deletion-eligible,
    partially cleaned, and effect-observed boundaries, verifying one suppression boundary and no duplicate application
    effect; and
-9. late or replayed pre-activation app payloads after activation, verifying suppression before delivery while retained
+10. late or replayed pre-activation app payloads after activation, verifying suppression before delivery while retained
    anchors, candidate state, pending publication, and other protocol recovery material remain available.
 
 The suite MUST compare canonical state and stable effect identities. It MUST NOT claim physical overwrite, deletion of

--- a/foundation/conformance.md
+++ b/foundation/conformance.md
@@ -83,6 +83,32 @@ These tests compare behavior and the projection above. They MUST NOT require a d
 snapshot encoding, process scheduler, or one snapshot per epoch. The owning normative rules are in
 [../protocol-core/durability.md](../protocol-core/durability.md).
 
+## Consensual history purge scenarios
+
+Conformance suites for [`marmot.group.history-purge.v1`](../app-components/history-purge-v1.md) MUST cover:
+
+1. a supported fixed member snapshot in which every account answers Yes and the direct child Commit atomically applies
+   the requested retention value and one reversible pre-activation plaintext suppression boundary;
+2. each missing, duplicate, extra, out-of-order, malformed, wrong-request, wrong-group, wrong-parent, and No approval,
+   verifying that no retention update or deletion effect is accepted;
+3. one explicit No and one silent member, verifying that neither produces a partial or group-wide completion state;
+4. a membership, identity, capability, admin-policy, retention, or unrelated canonical child Commit before
+   finalization, verifying that the old request expires and cannot authorize a later Commit;
+5. a leaf without `app_ephemeral` or component `0x800d` support, verifying that request creation and finalization are
+   blocked rather than treating the leaf as consenting;
+6. a branch that supersedes the authorizing Commit while its parent remains inside the rollback horizon, verifying that
+   suppression is withdrawn and destructive deletion has not begun;
+7. advancement until the request parent is outside the rollback horizon, verifying that best-effort deletion begins
+   only while the authorization remains on the settled selected branch;
+8. duplicate delivery and restart at the prepared, confirmed-not-applied, suppression-observed, deletion-eligible,
+   partially cleaned, and effect-observed boundaries, verifying one suppression boundary and no duplicate application
+   effect; and
+9. late or replayed pre-activation app payloads after activation, verifying suppression before delivery while retained
+   anchors, candidate state, pending publication, and other protocol recovery material remain available.
+
+The suite MUST compare canonical state and stable effect identities. It MUST NOT claim physical overwrite, deletion of
+external copies, or completion on another member's device.
+
 ## Exporter commitment
 
 The conformance exporter secret is:

--- a/foundation/conformance.md
+++ b/foundation/conformance.md
@@ -93,10 +93,10 @@ Conformance suites for [`marmot.group.history-purge.v1`](../app-components/histo
    verifying that no retention update or deletion effect is accepted;
 3. one explicit No and one silent member, verifying that neither produces a partial or group-wide completion state;
    then deliver one member's valid No response to client A but not client B, restart that member's signer, and request a
-   distinct Yes proof for the same request. The conforming signer MUST refuse to produce the Yes proof. Given the same
-   candidate parent and incomplete or No-bearing authorization Commit bytes, clients A and B MUST reach identical
-   rejection and effect projections despite their asymmetric response delivery: no retention, suppression, or deletion
-   effect starts;
+   distinct Yes proof for the same request. The conforming signer MUST refuse to produce the Yes proof. For each of two
+   same-parent candidate Commits, one with that member's approval missing and one carrying that member's No proof,
+   deliver the exact same Commit bytes to clients A and B. Both clients MUST reject the Commit with identical effect
+   projections despite their asymmetric response delivery: no retention, suppression, or deletion effect starts;
 4. a membership, identity, capability, admin-policy, retention, or unrelated canonical child Commit before
    finalization, verifying that the old request expires and cannot authorize a later Commit;
 5. a leaf without `app_ephemeral` or component `0x800d` support, verifying that request creation and finalization are

--- a/foundation/conformance.md
+++ b/foundation/conformance.md
@@ -92,6 +92,8 @@ Conformance suites for [`marmot.group.history-purge.v1`](../app-components/histo
 2. each missing, duplicate, extra, out-of-order, malformed, wrong-request, wrong-group, wrong-parent, and No approval,
    verifying that no retention update or deletion effect is accepted;
 3. one explicit No and one silent member, verifying that neither produces a partial or group-wide completion state;
+   then a No-then-Yes sequence from one member, including restart after the No, verifying that the later Yes is invalid,
+   the request remains rejected, and no retention, suppression, or deletion effect starts;
 4. a membership, identity, capability, admin-policy, retention, or unrelated canonical child Commit before
    finalization, verifying that the old request expires and cannot authorize a later Commit;
 5. a leaf without `app_ephemeral` or component `0x800d` support, verifying that request creation and finalization are
@@ -103,8 +105,8 @@ Conformance suites for [`marmot.group.history-purge.v1`](../app-components/histo
 8. advancement until the request parent is outside the rollback horizon, verifying that best-effort deletion begins
    only while the authorization remains on the settled selected branch;
 9. duplicate delivery and restart at the prepared, confirmed-not-applied, suppression-observed, deletion-eligible,
-   partially cleaned, and effect-observed boundaries, verifying one suppression boundary and no duplicate application
-   effect; and
+   partially cleaned, and effect-observed boundaries, verifying one suppression boundary, completion of all remaining
+   eligible deletion work after restart, and one effective output per stable effect identity; and
 10. late or replayed pre-activation app payloads after activation, verifying suppression before delivery while retained
    anchors, candidate state, pending publication, and other protocol recovery material remain available.
 

--- a/foundation/conformance.md
+++ b/foundation/conformance.md
@@ -92,8 +92,11 @@ Conformance suites for [`marmot.group.history-purge.v1`](../app-components/histo
 2. each missing, duplicate, extra, out-of-order, malformed, wrong-request, wrong-group, wrong-parent, and No approval,
    verifying that no retention update or deletion effect is accepted;
 3. one explicit No and one silent member, verifying that neither produces a partial or group-wide completion state;
-   then a No-then-Yes sequence from one member, including restart after the No, verifying that the later Yes is invalid,
-   the request remains rejected, and no retention, suppression, or deletion effect starts;
+   then deliver one member's valid No response to client A but not client B, restart that member's signer, and request a
+   distinct Yes proof for the same request. The conforming signer MUST refuse to produce the Yes proof. Given the same
+   candidate parent and incomplete or No-bearing authorization Commit bytes, clients A and B MUST reach identical
+   rejection and effect projections despite their asymmetric response delivery: no retention, suppression, or deletion
+   effect starts;
 4. a membership, identity, capability, admin-policy, retention, or unrelated canonical child Commit before
    finalization, verifying that the old request expires and cannot authorize a later Commit;
 5. a leaf without `app_ephemeral` or component `0x800d` support, verifying that request creation and finalization are

--- a/foundation/conformance.md
+++ b/foundation/conformance.md
@@ -88,7 +88,9 @@ snapshot encoding, process scheduler, or one snapshot per epoch. The owning norm
 Conformance suites for [`marmot.group.history-purge.v1`](../app-components/history-purge-v1.md) MUST cover:
 
 1. an active non-admin creates the feature-owned request, another active member relays it into temporary GroupContext
-   state, and no actor thereby gains authority to commit the retention update or accepted finalization;
+   state, and no actor thereby gains authority to commit the retention update or accepted finalization. The suite MUST
+   accept only the exact paired `0x800d` required-component-list addition and reject any unrelated required-component or
+   GroupContext mutation by that actor;
 2. a supported fixed member snapshot in which every account adds one canonical Yes and the active-admin terminal Commit
    atomically applies the requested retention value, removes the temporary state, and installs one reversible
    pre-activation plaintext suppression boundary;
@@ -98,7 +100,9 @@ Conformance suites for [`marmot.group.history-purge.v1`](../app-components/histo
    does not, and both then receive the exact rejected Commit bytes. Both clients MUST select the same rejected terminal
    identity. After restart, a later Yes state update or accepted finalization for that request MUST be invalid and no
    suppression or deletion begins. A signer asked for No then Yes before terminal selection MUST durably refuse the
-   second proof; a validator presented conflicting proofs MUST reject them;
+   second proof; a signer whose Yes is already in canonical open state MUST NOT produce No, and a rejected finalization
+   carrying that signer's No MUST be rejected before and after restart even when the No proof was delivered to only one
+   client. A validator presented conflicting proofs MUST reject them;
 5. proposer cancellation while open, cancellation by any other member, cancellation after a terminal transition, and
    replay of a valid cancellation, verifying that only the first case can become the canonical cancelled identity;
 6. request intervals at one second and exactly `604800` seconds, an interval of `604801`, Yes and accepted-proof
@@ -109,7 +113,8 @@ Conformance suites for [`marmot.group.history-purge.v1`](../app-components/histo
 8. a leaf without `app_ephemeral`, `app_data_update`, or component `0x800d` support, verifying that request creation and
    finalization are blocked rather than treating the leaf as consenting;
 9. every terminal proposal set with each required proposal missing or duplicated and with one unrelated proposal added,
-   verifying rejection with no retention, suppression, or deletion effect;
+   including an unrelated required-component-list mutation by a non-admin No signer or proposer, verifying rejection
+   with no retention, suppression, or deletion effect;
 10. competing same-parent accepted, rejected, cancelled, expired, and superseded terminal Commits delivered in
     different orders, verifying that canonical convergence alone selects one stable terminal identity and replays of
     losing transitions are inert;

--- a/foundation/registries.md
+++ b/foundation/registries.md
@@ -112,6 +112,9 @@ seal), kind `10002` (NIP-65 relay list), and kind `10050` (NIP-17 DM inbox relay
 | `452`   | Multi-device join authorization v1 | Local signing template, not relayed | [multi-device-join-authorization-v1.md](../app-components/multi-device-join-authorization-v1.md) |
 | `453`   | History-purge control event         | Marmot app payload                  | [history-purge-v1.md](../app-components/history-purge-v1.md) |
 | `454`   | History-purge member decision       | Local signing template, not relayed | [history-purge-v1.md](../app-components/history-purge-v1.md) |
+| `455`   | History-purge request proof         | Local signing template, not relayed | [history-purge-v1.md](../app-components/history-purge-v1.md) |
+| `456`   | History-purge cancellation proof    | Local signing template, not relayed | [history-purge-v1.md](../app-components/history-purge-v1.md) |
+| `457`   | History-purge terminal proof        | Local signing template, not relayed | [history-purge-v1.md](../app-components/history-purge-v1.md) |
 | `1009`  | Message edit                        | Marmot app payload                  | [application-messages.md](application-messages.md)      |
 | `1200`  | Agent text stream start             | Marmot app payload                  | [agent-text-streams-quic.md](../features/agent-text-streams-quic.md) |
 | `1210`  | Group system event                  | Marmot app payload                  | [application-messages.md](application-messages.md)      |
@@ -135,7 +138,7 @@ Kind `451` is the local signing event for current push token-record and removal 
 distinct `d` tags and are defined by [push-notifications.md](../features/push-notifications.md). Its signature-only
 carrier is feature-specific and does not use `MarmotAuthorizationProof`.
 
-Kinds `450`, `451`, `452`, and `454` are local signing templates, not transport objects. Clients MUST NOT publish them to
+Kinds `450`, `451`, `452`, `454`, `455`, `456`, and `457` are local signing templates, not transport objects. Clients MUST NOT publish them to
 relays. Legacy-group verification of push signatures created with kind `450` does not change the current allocation:
 clients MUST NOT produce a new push owner proof with kind `450`.
 

--- a/foundation/registries.md
+++ b/foundation/registries.md
@@ -24,6 +24,7 @@ Marmot app components use MLS private-use component ids.
 | `0x800a`     | `marmot.authorization.multi-device-join.v1`     | [draft](../app-components/multi-device-join-authorization-v1.md)    |
 | `0x800b`     | `marmot.group.encrypted-media.v2`               | [doc](../app-components/group-encrypted-media-v2.md)                |
 | `0x800c`     | `marmot.group.lifecycle.v1`                     | [doc](../app-components/group-lifecycle-v1.md)                      |
+| `0x800d`     | `marmot.group.history-purge.v1`                 | [doc](../app-components/history-purge-v1.md)                        |
 
 ## Upstream MLS extension draft ids
 
@@ -109,6 +110,8 @@ seal), kind `10002` (NIP-65 relay list), and kind `10050` (NIP-17 DM inbox relay
 | `450`   | Account identity proof v2 event     | Local signing template, not relayed | [account-identity-proof-v2.md](../app-components/account-identity-proof-v2.md) |
 | `451`   | Push owner proof event              | Local signing template, not relayed | [push-notifications.md](../features/push-notifications.md) |
 | `452`   | Multi-device join authorization v1 | Local signing template, not relayed | [multi-device-join-authorization-v1.md](../app-components/multi-device-join-authorization-v1.md) |
+| `453`   | History-purge control event         | Marmot app payload                  | [history-purge-v1.md](../app-components/history-purge-v1.md) |
+| `454`   | History-purge member decision       | Local signing template, not relayed | [history-purge-v1.md](../app-components/history-purge-v1.md) |
 | `1009`  | Message edit                        | Marmot app payload                  | [application-messages.md](application-messages.md)      |
 | `1200`  | Agent text stream start             | Marmot app payload                  | [agent-text-streams-quic.md](../features/agent-text-streams-quic.md) |
 | `1210`  | Group system event                  | Marmot app payload                  | [application-messages.md](application-messages.md)      |
@@ -132,7 +135,7 @@ Kind `451` is the local signing event for current push token-record and removal 
 distinct `d` tags and are defined by [push-notifications.md](../features/push-notifications.md). Its signature-only
 carrier is feature-specific and does not use `MarmotAuthorizationProof`.
 
-Kinds `450`, `451`, and `452` are local signing templates, not transport objects. Clients MUST NOT publish them to
+Kinds `450`, `451`, `452`, and `454` are local signing templates, not transport objects. Clients MUST NOT publish them to
 relays. Legacy-group verification of push signatures created with kind `450` does not change the current allocation:
 clients MUST NOT produce a new push owner proof with kind `450`.
 

--- a/layout.md
+++ b/layout.md
@@ -47,6 +47,7 @@ app-components/
   admin-policy-v1.md
   nostr-routing-v1.md
   message-retention-v1.md
+  history-purge-v1.md
   agent-text-stream-quic-v1.md
   group-avatar-url-v1.md
   group-encrypted-media-v1.md
@@ -65,6 +66,7 @@ features/
   agent-text-streams-quic.md
   push-notifications.md
   multi-device.md
+  consensual-history-purge.md
 implementation-model.md
 ```
 

--- a/protocol-core/retained-history.md
+++ b/protocol-core/retained-history.md
@@ -86,6 +86,25 @@ than `app_payload_past_epoch_limit` canonical epoch advances can conformantly lo
 epochs even when their transport objects remain available. Applications that require complete long-term history need a
 separate protocol mechanism; transport retention alone does not extend the MLS decryption window.
 
+## Authorized application plaintext purge
+
+A selected Commit carrying a valid [`marmot.group.history-purge.v1`](../app-components/history-purge-v1.md)
+authorization establishes one reversible local suppression boundary at its resulting activation epoch. The client MUST
+suppress every delivered Marmot app payload whose MLS source epoch is less than that boundary before any application
+surface can render or emit it. If a later convergence pass supersedes the Commit while its parent remains inside the
+rollback horizon, the client withdraws the suppression with the Commit's other application effects and performs no
+destructive deletion.
+
+Idempotent local best-effort deletion becomes eligible only after convergence is settled, the selected branch still
+contains the authorization, and the request's parent epoch is outside the current canonical tip's rollback horizon. The
+client then deletes application-controlled plaintext and resumes unfinished cleanup after restart, as defined by
+[consensual-history-purge.md](../features/consensual-history-purge.md).
+
+The suppression boundary does not move the retained anchor or the app-payload decryption window. It MUST NOT release
+candidate-authentication state, application secret-tree state, pending publication data, replay markers, or any other
+protocol recovery material before that material's release condition in this document is reached. Receiving a No,
+silence, an unsupported member, or expiry of a request creates no suppression boundary.
+
 ## Pruning
 
 After convergence reaches a settled selected branch, a client SHOULD prune retained states older than the group's

--- a/scripts/spec_validate.py
+++ b/scripts/spec_validate.py
@@ -193,6 +193,8 @@ def check_history_purge_v1() -> None:
 
     component_fragments = [
         "at most one open request per group",
+        "parent_group_context_hash` MUST equal `SHA-256(TLS-serialize(candidate_parent_group_context))`",
+        "without Marmot-specific re-encoding",
         "contains at\nmost one record per account",
         "A No is not an advisory app event",
         "MUST refuse a second or conflicting decision",
@@ -204,6 +206,8 @@ def check_history_purge_v1() -> None:
         "Best-effort destructive cleanup begins only after the authorization remains selected",
         "resumes after restart",
         "external copies are outside enforceable scope",
+        "A receipt is valid only when `finalization_id` identifies the accepted finalization",
+        "non-canonical finalization is invalid and MUST NOT contribute to a completion projection",
     ]
     for fragment in component_fragments:
         require(component, fragment, component_name)

--- a/scripts/spec_validate.py
+++ b/scripts/spec_validate.py
@@ -111,7 +111,11 @@ def check_registry_and_components(paths: list[Path]) -> None:
     unique([m.group("name") for m in components], "component names")
     unique([m.group("doc") for m in components], "component documents")
 
-    kinds = [m.group("kind") for m in REGISTRY_KIND_RE.finditer(registry)]
+    kinds_heading = "## Nostr event kinds used by Marmot"
+    if kinds_heading not in registry:
+        fail("foundation/registries.md is missing the Nostr event-kinds section")
+    kinds_section = registry.split(kinds_heading, 1)[1].split("\n## ", 1)[0]
+    kinds = [match.group("kind") for match in REGISTRY_KIND_RE.finditer(kinds_section)]
     if not kinds:
         fail("foundation/registries.md has no parseable Nostr kind rows")
     unique(kinds, "Nostr event kinds")

--- a/scripts/spec_validate.py
+++ b/scripts/spec_validate.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Deterministic validation for Marmot specification pull requests."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import NoReturn
+from urllib.parse import unquote, urlsplit
+
+ROOT = Path(__file__).resolve().parents[1]
+SURFACES = {"foundation", "protocol-core", "app-components", "transports", "features"}
+LINK_RE = re.compile(r"!?\[[^\]]*\]\(([^)]+)\)")
+REGISTRY_COMPONENT_RE = re.compile(
+    r"^\| `(?P<id>0x8[0-9a-f]{3})`[ \t]+\| `(?P<name>[^`]+)`[ \t]+\| "
+    r"\[(?:doc|draft)\]\(\.\./app-components/(?P<doc>[^)]+\.md)\)[ \t]+\|$",
+    re.MULTILINE,
+)
+REGISTRY_KIND_RE = re.compile(
+    r"^\| `(?P<kind>\d+)`[ \t]+\|.*\| \[[^]]+\]\([^)]+\)[ \t]+\|$", re.MULTILINE
+)
+
+
+class ValidationError(RuntimeError):
+    pass
+
+
+def run(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        cwd=ROOT,
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def fail(message: str) -> NoReturn:
+    raise ValidationError(message)
+
+
+def read_utf8(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as error:
+        fail(f"{path.relative_to(ROOT)} is not valid UTF-8: {error}")
+
+
+def changed_files(base: str, head: str) -> list[Path]:
+    result = run("git", "diff", "--name-only", "--diff-filter=ACMR", f"{base}...{head}")
+    return [ROOT / line for line in result.stdout.splitlines() if line]
+
+
+def check_diff_hygiene(base: str, head: str) -> None:
+    result = run("git", "diff", "--check", f"{base}...{head}", check=False)
+    if result.returncode:
+        fail("git diff --check failed:\n" + result.stdout + result.stderr)
+    print("PASS diff hygiene (git diff --check)")
+
+
+def link_target(raw: str) -> str:
+    target = raw.strip()
+    if target.startswith("<") and ">" in target:
+        return target[1 : target.index(">")]
+    # Markdown titles follow the URL after whitespace. Repository paths do not contain spaces.
+    return target.split(maxsplit=1)[0]
+
+
+def check_markdown(paths: list[Path]) -> None:
+    checked = 0
+    for path in paths:
+        if path.suffix.lower() != ".md" or not path.exists():
+            continue
+        text = read_utf8(path)
+        checked += 1
+        for match in LINK_RE.finditer(text):
+            target = link_target(match.group(1))
+            parsed = urlsplit(target)
+            if parsed.scheme or target.startswith(("#", "//")):
+                continue
+            relative = unquote(parsed.path)
+            if not relative:
+                continue
+            resolved = (path.parent / relative).resolve()
+            try:
+                resolved.relative_to(ROOT)
+            except ValueError:
+                fail(f"{path.relative_to(ROOT)} links outside the repository: {target}")
+            if not resolved.exists():
+                line = text.count("\n", 0, match.start()) + 1
+                fail(f"{path.relative_to(ROOT)}:{line} has a missing relative link: {target}")
+    print(f"PASS changed Markdown UTF-8 and relative links ({checked} files)")
+
+
+def unique(values: list[str], label: str) -> None:
+    duplicates = sorted({value for value in values if values.count(value) > 1})
+    if duplicates:
+        fail(f"duplicate {label}: {', '.join(duplicates)}")
+
+
+def check_registry_and_components(paths: list[Path]) -> None:
+    registry = read_utf8(ROOT / "foundation/registries.md")
+    components = list(REGISTRY_COMPONENT_RE.finditer(registry))
+    if not components:
+        fail("foundation/registries.md has no parseable component registry rows")
+    unique([m.group("id") for m in components], "component ids")
+    unique([m.group("name") for m in components], "component names")
+    unique([m.group("doc") for m in components], "component documents")
+
+    kinds = [m.group("kind") for m in REGISTRY_KIND_RE.finditer(registry)]
+    if not kinds:
+        fail("foundation/registries.md has no parseable Nostr kind rows")
+    unique(kinds, "Nostr event kinds")
+
+    registry_by_doc = {m.group("doc"): (m.group("id"), m.group("name")) for m in components}
+    layout = read_utf8(ROOT / "layout.md")
+    component_index = read_utf8(ROOT / "app-components/README.md")
+
+    for path in paths:
+        relative = path.relative_to(ROOT)
+        if len(relative.parts) != 2 or relative.parts[0] not in SURFACES or path.suffix != ".md":
+            continue
+        if path.name in {"README.md", "AGENTS.md"}:
+            continue
+        if path.name not in layout:
+            fail(f"{relative} is missing from layout.md")
+        surface_index = read_utf8(ROOT / relative.parts[0] / "README.md")
+        if path.name not in surface_index:
+            fail(f"{relative} is missing from {relative.parts[0]}/README.md")
+
+        if relative.parts[0] != "app-components":
+            continue
+        text = read_utf8(path)
+        id_match = re.search(r"^- Component id: `(0x[0-9a-f]{4})`$", text, re.MULTILINE)
+        name_match = re.search(r"^- Name: `([^`]+)`$", text, re.MULTILINE)
+        if not id_match or not name_match:
+            fail(f"{relative} must declare one component id and name")
+        assert id_match is not None and name_match is not None
+        registered = registry_by_doc.get(path.name)
+        declared = (id_match.group(1), name_match.group(1))
+        if registered != declared:
+            fail(f"{relative} declares {declared}, registry has {registered}")
+        if path.name not in component_index:
+            fail(f"{relative} is missing from app-components/README.md")
+
+    print(f"PASS registry uniqueness and changed component/surface consistency ({len(components)} components)")
+
+
+def check_surface_boundaries(paths: list[Path]) -> None:
+    forbidden = re.compile(
+        r"Rust crate|database table|queue shape|retry worker|local API|test harness|"
+        r"\bdarkmatter\b|CgkaEngine|PendingStateRef|drain_auto_publish|"
+        r"drain_auto_proposals|confirm_published|publish_failed"
+    )
+    findings: list[str] = []
+    for path in paths:
+        relative = path.relative_to(ROOT)
+        if path.suffix != ".md" or not path.exists() or path.name in {"AGENTS.md"}:
+            continue
+        if relative.parts[0] not in SURFACES:
+            continue
+        text = read_utf8(path)
+        for number, line in enumerate(text.splitlines(), 1):
+            if forbidden.search(line):
+                findings.append(f"{relative}:{number}: {line.strip()}")
+    if findings:
+        fail("implementation details leaked into changed spec surfaces:\n" + "\n".join(findings))
+    print("PASS changed normative surface-boundary leak check")
+
+
+def require(text: str, fragment: str, source: str) -> None:
+    normalized_text = " ".join(text.split())
+    normalized_fragment = " ".join(fragment.split())
+    if normalized_fragment not in normalized_text:
+        fail(f"{source} is missing focused V1 assertion: {fragment}")
+
+
+def check_history_purge_v1() -> None:
+    component_name = "app-components/history-purge-v1.md"
+    conformance_name = "foundation/conformance.md"
+    registry_name = "foundation/registries.md"
+    component = read_utf8(ROOT / component_name)
+    conformance = read_utf8(ROOT / conformance_name)
+    registry = read_utf8(ROOT / registry_name)
+
+    component_fragments = [
+        "at most one open request per group",
+        "contains at\nmost one record per account",
+        "A No is not an advisory app event",
+        "MUST refuse a second or conflicting decision",
+        "one valid Yes for every `members` account",
+        "Every terminal Commit removes the GroupContext `0x800d` entry",
+        "Any missing, duplicate, or\nextra proposal makes the terminal transition invalid.",
+        "Expiry is never consent.",
+        "A client MUST durably install one reversible suppression boundary",
+        "Best-effort destructive cleanup begins only after the authorization remains selected",
+        "resumes after restart",
+        "external copies are outside enforceable scope",
+    ]
+    for fragment in component_fragments:
+        require(component, fragment, component_name)
+
+    conformance_fragments = [
+        "## Consensual history purge scenarios",
+        "wrong-signer decision",
+        "validator presented conflicting proofs MUST reject them",
+        "timeout, silence, restart, and expiry never produce consent",
+        "verifying rejection with no retention, suppression, or deletion effect",
+        "suppression is withdrawn and destructive deletion has not begun",
+        "completion of remaining\neligible cleanup after restart",
+        "MUST NOT claim physical overwrite, deletion of external copies",
+    ]
+    for fragment in conformance_fragments:
+        require(conformance, fragment, conformance_name)
+
+    registry_fragments = [
+        "| `0x800d`     | `marmot.group.history-purge.v1`",
+        "| `453`   | History-purge control event",
+        "| `454`   | History-purge member decision",
+        "| `455`   | History-purge request proof",
+        "| `456`   | History-purge cancellation proof",
+        "| `457`   | History-purge terminal proof",
+    ]
+    for fragment in registry_fragments:
+        require(registry, fragment, registry_name)
+
+    print("PASS focused history-purge V1 assertions (authorization, lifecycle, replay, restart, recovery limits)")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base", required=True, help="base commit")
+    parser.add_argument("--head", default="HEAD", help="head commit")
+    parser.add_argument("--mode", choices=("fast", "focused", "all"), default="all")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        run("git", "rev-parse", "--verify", f"{args.base}^{{commit}}")
+        run("git", "rev-parse", "--verify", f"{args.head}^{{commit}}")
+        paths = changed_files(args.base, args.head)
+        if args.mode in {"fast", "all"}:
+            check_diff_hygiene(args.base, args.head)
+            check_markdown(paths)
+            check_registry_and_components(paths)
+            check_surface_boundaries(paths)
+        if args.mode in {"focused", "all"}:
+            check_history_purge_v1()
+    except (ValidationError, subprocess.CalledProcessError) as error:
+        print(f"FAIL: {error}", file=sys.stderr)
+        return 1
+    print(f"PASS spec validation mode={args.mode} base={args.base} head={args.head}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Define one parent-bound consensual history-purge request for a fixed snapshot of active account identities.
- Require every snapshotted account to return an explicit signed Yes decision before an admin can commit the canonical purge authorization; any No, missing response, parent change, membership change, policy change, or unsupported client blocks deletion.
- Limit the authorized effect to idempotent local best-effort deletion of pre-activation application plaintext while preserving protocol recovery material, prospective retention semantics, replay safety, and clear external-copy limits.
- Add focused conformance scenarios for unanimous approval, rejection, expiry, capability gating, replay, restart, and recovery-material preservation.

## Verification

- Focused consensual-history-purge conformance assertions: PASS.
- Repository fast gate through `hermes_test_gate.py`: PASS for Markdown links, registry uniqueness, required component sections, surface-boundary leak checks, and `git diff --check`.
- Commit signature verified by GitHub for `28a9d7c689a7a5a052ba8ec8b0e0729bbb36f53f`.

Tracks #418. This pull request does not implement MDK or client behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for unanimous, one-time history purges alongside changes to prospective message-retention duration.
  - Eligible application content is suppressed before display and may be cleaned up after authorization settles, without changing pinned expiry or protocol-data retention.
  - Added safeguards for validation, conflicting decisions, expiration, rollback, restart recovery, and duplicate processing.
  - Registered the history-purge component and related event types.

- **Documentation**
  - Added specifications covering feature behavior, retention, protocol handling, components, registries, and conformance scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->